### PR TITLE
Minor change in kernel-headers logic to avoid bind-mounting more than once

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -514,6 +514,11 @@ func createMountSpec(
 			lcp := longestCommonPath(filtLinks)
 			lcp = filepath.Clean(lcp)
 
+			// Skip if we are matching the original (above) mount-spec.
+			if lcp == source && lcp == dest {
+				continue
+			}
+
 			// if the lcp is underneath the source, ignore it
 			if !strings.HasPrefix(lcp, source+"/") {
 				m := specs.Mount{


### PR DESCRIPTION
createMountSpec() function can end up creating duplicated mount-spec entries in scenarios where a softlink is found to be pointing to the primary (original) mount-spec passed to the function. This is easily reproduced in CentOS and Fedora setups. Fix is to simply identify the overlapping case and skip processing.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>