### PR TITLE
Ensure that sysbox-mgr connection to Docker API is properly closed.

### DIFF
--- a/mgr.go
+++ b/mgr.go
@@ -574,6 +574,7 @@ func (mgr *SysboxMgr) autoRemoveCheck(id string) {
 		logrus.Debugf("autoRemoveCheck: Docker connection failed for %s: %s\n", id, err)
 		return
 	}
+	defer docker.Disconnect()
 
 	ci, err := docker.ContainerGetInfo(id)
 	if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -393,7 +393,12 @@ func sanitizeRootfs(id, rootfs string) string {
 	// to <container-id>.
 
 	docker, err := dockerUtils.DockerConnect()
-	if err == nil && docker.ContainerIsDocker(id) {
+	if err != nil {
+		return rootfs
+	}
+	defer docker.Disconnect()
+
+	if docker.ContainerIsDocker(id) {
 		if strings.Contains(rootfs, "overlay2") && filepath.Base(rootfs) == "merged" {
 			return filepath.Dir(rootfs)
 		}


### PR DESCRIPTION
Prior to this change, sysbox-mgr had a bug where it was not properly
closing the file descriptor handle for the connection to the
Docker API. As a result, the sysbox-mgr was leaking file-descriptors,
which would cause failures after hitting the Linux limit for
max file descriptors opened by a process (typically 1024).

This change fixes this by ensuring sysbox-mgr closes the
Docker API connection file descriptor appropriately.

Signed-off-by: ctalledo <ctalledo@nestybox.com>