### PR TITLE
Optimize chown for host dirs mounted on sys container special paths.

### DIFF
--- a/volMgr/volMgr.go
+++ b/volMgr/volMgr.go
@@ -245,7 +245,7 @@ func (m *vmgr) SyncOutAndDestroyAll() {
 }
 
 // rsyncVol performs an rsync from src to dest; if shiftUids is true, the rsync
-// modifies the ownership of files copied to dest to match the givne uid(gid).
+// modifies the ownership of files copied to dest to match the given uid(gid).
 func (m *vmgr) rsyncVol(src, dest string, uid, gid uint32, shiftUids bool) error {
 
 	var cmd *exec.Cmd


### PR DESCRIPTION
When using uid-shifting, we normally mount shiftfs on host dirs that
are bind-mounted into a sys container.

However, if the bind-mount is on a "special path" in the container
(e.g., such as /var/lib/docker, /var/lib/kubelet), we don't mount
shiftfs on the host dir because it will break the sys container apps
that operate on those dirs (e.g., docker, k8s, etc.). Instead, we
change the ownership of the host dir that is being mounted into the
special path, such that it matches the sys container's root user uid:gid.

This chown operation can be slow, specially if the host dir path
is heavily populated (i.e., has lots of subdirs & files), since it
needs to be done recursively.

This commit optimizes the chown with a couple of changes:

1) Before proceeding with the chown, we first check if it's even
required, by inspecting the ownership of a subset of files in the host
dir that is being mounted.

2) If the chown is necessary, we now use the chown(1) command instead
of golang's filepath.Walk(), as the former is twice as fast as the latter.

Signed-off-by: ctalledo <ctalledo@nestybox.com>