### PR TITLE
Use short container IDs in sysbox-mgr logs.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mrunalp/fileutils v0.0.0-20171103030105-7d4729fb3618
 	github.com/nestybox/sysbox-ipc v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/dockerUtils v0.0.0-00010101000000-000000000000
+	github.com/nestybox/sysbox-libs/formatter v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/utils v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-runc v0.0.0-00010101000000-000000000000
 	github.com/opencontainers/runc v0.0.0-00010101000000-000000000000
@@ -24,6 +25,8 @@ replace github.com/nestybox/sysbox-ipc => ../sysbox-ipc
 replace github.com/nestybox/sysbox-runc => ../sysbox-runc
 
 replace github.com/nestybox/sysbox-libs/utils => ../sysbox-libs/utils
+
+replace github.com/nestybox/sysbox-libs/formatter => ../sysbox-libs/formatter
 
 replace github.com/nestybox/sysbox-libs/dockerUtils => ../sysbox-libs/dockerUtils
 

--- a/shiftfsMgr/shiftfsMgr.go
+++ b/shiftfsMgr/shiftfsMgr.go
@@ -28,6 +28,7 @@ import (
 	"os/exec"
 	"sync"
 
+	"github.com/nestybox/sysbox-libs/formatter"
 	intf "github.com/nestybox/sysbox-mgr/intf"
 	"github.com/nestybox/sysbox-runc/libsysbox/shiftfs"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -106,7 +107,8 @@ func (sm *mgr) Unmark(id string, mount []configs.ShiftfsMount) error {
 		// Remove matching container-id from mpMap entry
 		ids, err := removeID(ids, id)
 		if err != nil {
-			return fmt.Errorf("did not find container id %s in mount-point map entry for %s", id, m.Source)
+			return fmt.Errorf("did not find container id %s in mount-point map entry for %s",
+				formatter.ContainerID{id}, m.Source)
 		}
 
 		// If after removal the mpMap entry is empty it means there are no more containers

--- a/subidAlloc/subidAllocSimple.go
+++ b/subidAlloc/subidAllocSimple.go
@@ -30,6 +30,7 @@ import (
 	"sort"
 
 	mapset "github.com/deckarep/golang-set"
+	"github.com/nestybox/sysbox-libs/formatter"
 	intf "github.com/nestybox/sysbox-mgr/intf"
 	"github.com/nestybox/sysbox-runc/libcontainer/user"
 	"github.com/sirupsen/logrus"
@@ -131,12 +132,13 @@ func getCommonRanges(uidRanges, gidRanges []user.SubID) []user.SubID {
 // Implements intf.SubidAlloc.Alloc
 func (sub *subidAlloc) Alloc(id string, size uint64) (uint32, uint32, error) {
 	subid := sub.idRange
-	logrus.Debugf("Alloc(%s, %v) = %v, %v", id, size, subid, subid)
+	logrus.Debugf("Alloc(%s, %v) = %v, %v",
+		formatter.ContainerID{id}, size, subid, subid)
 	return uint32(subid.SubID), uint32(subid.SubID), nil
 }
 
 // Implements intf.SubidAlloc.Free
 func (sub *subidAlloc) Free(id string) error {
-	logrus.Debugf("Free(%v)", id)
+	logrus.Debugf("Free(%v)", formatter.ContainerID{id})
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>