### PR TITLE
Fix bug when parsing of subid ranges in /etc/login.defs.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -207,19 +207,19 @@ func getSubidLimits(file string) ([]uint64, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.Contains(line, "SUB_UID_MIN") {
-			valStr := strings.Split(line, " ")[1]
+			valStr := strings.Fields(line)[1]
 			limits[0], err = strconv.ParseUint(valStr, 10, 64)
 		}
 		if strings.Contains(line, "SUB_UID_MAX") {
-			valStr := strings.Split(line, " ")[1]
+			valStr := strings.Fields(line)[1]
 			limits[1], err = strconv.ParseUint(valStr, 10, 64)
 		}
 		if strings.Contains(line, "SUB_GID_MIN") {
-			valStr := strings.Split(line, " ")[1]
+			valStr := strings.Fields(line)[1]
 			limits[2], err = strconv.ParseUint(valStr, 10, 64)
 		}
 		if strings.Contains(line, "SUB_GID_MAX") {
-			valStr := strings.Split(line, " ")[1]
+			valStr := strings.Fields(line)[1]
 			limits[3], err = strconv.ParseUint(valStr, 10, 64)
 		}
 		if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -203,27 +203,27 @@ func getSubidLimits(file string) ([]uint64, error) {
 	}
 	defer f.Close()
 
+	tokens := map[string]uint{
+		"SUB_UID_MIN": 0,
+		"SUB_UID_MAX": 1,
+		"SUB_GID_MIN": 2,
+		"SUB_GID_MAX": 3,
+	}
+
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.Contains(line, "SUB_UID_MIN") {
-			valStr := strings.Fields(line)[1]
-			limits[0], err = strconv.ParseUint(valStr, 10, 64)
-		}
-		if strings.Contains(line, "SUB_UID_MAX") {
-			valStr := strings.Fields(line)[1]
-			limits[1], err = strconv.ParseUint(valStr, 10, 64)
-		}
-		if strings.Contains(line, "SUB_GID_MIN") {
-			valStr := strings.Fields(line)[1]
-			limits[2], err = strconv.ParseUint(valStr, 10, 64)
-		}
-		if strings.Contains(line, "SUB_GID_MAX") {
-			valStr := strings.Fields(line)[1]
-			limits[3], err = strconv.ParseUint(valStr, 10, 64)
-		}
-		if err != nil {
-			return limits, fmt.Errorf("failed to parse line %s: %s", line, err)
+		for token, pos := range tokens {
+			if strings.Contains(line, token) {
+				valStr := strings.Fields(line)
+				if len(valStr) < 2 {
+					return limits, fmt.Errorf("failed to parse file %s: line %s: expected two fields, found %d field(s)", file, line, len(valStr))
+				}
+				limits[pos], err = strconv.ParseUint(valStr[1], 10, 64)
+				if err != nil {
+					return limits, fmt.Errorf("failed to parse line %s: %s", line, err)
+				}
+			}
 		}
 	}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -325,13 +325,13 @@ func TestGetSubidLimits(t *testing.T) {
 	// fake login.defs data
 	fileData := `# some comments
 some data
-SUB_UID_MIN 100000
+SUB_UID_MIN    100000
 some data
-SUB_UID_MAX 600100000
+SUB_UID_MAX\t 600100000
 some data
 SUB_GID_MIN 100000
 some data
-SUB_GID_MAX 2147483648
+SUB_GID_MAX\t\t 2147483648
 # some more comments`
 
 	want := []uint64{100000, 600100000, 100000, 2147483648}
@@ -348,7 +348,6 @@ some data
 	if err := testGetSubidLimitsHelper(fileData, want); err != nil {
 		t.Errorf(err.Error())
 	}
-
 }
 
 func TestGetLibModMounts(t *testing.T) {


### PR DESCRIPTION
When parsing the file, entries may be separated by any unicode space characters
(e.g., space, tab, etc.). Prior to this change, the code was assuming it had to
be the space character. This failed when running Sysbox in a Fedora-32 kernel,
in which tabs where used to separate the fields.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>