### PR TITLE
Create /etc/sub{g,u}id if they don't exist

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -132,14 +132,19 @@ func writeSubidFile(path string, subID []user.SubID) error {
 		buf.WriteString(l)
 	}
 
-	return ioutil.WriteFile(path, []byte(buf.String()), 644)
+	return ioutil.WriteFile(path, []byte(buf.String()), 0644)
 }
 
 func configSubidRange(path string, size, min, max uint64) error {
 
 	subID, err := user.ParseSubIDFile(path)
 	if err != nil {
-		return fmt.Errorf("error parsing file %s: %s", path, err)
+		if os.IsNotExist(err) {
+			// We will create an new file with only the "sysbox" entry
+			subID = []user.SubID{}
+		} else {
+			return fmt.Errorf("error parsing file %s: %s", path, err)
+		}
 	}
 
 	// Check if there are any subids configured for user "sysbox"

--- a/utils_test.go
+++ b/utils_test.go
@@ -207,7 +207,7 @@ func testConfigSubidRangeHelper(subidFilePre, subidFilePost string, size, min, m
 	}
 	defer os.RemoveAll(f.Name())
 
-	if err := ioutil.WriteFile(f.Name(), []byte(subidFilePre), 644); err != nil {
+	if err := ioutil.WriteFile(f.Name(), []byte(subidFilePre), 0644); err != nil {
 		return fmt.Errorf("failed to write file %s: %v", f.Name(), err)
 	}
 
@@ -294,7 +294,7 @@ func testGetSubidLimitsHelper(fileData string, want []uint64) error {
 		return fmt.Errorf("failed to create temp file: %v", err)
 	}
 
-	if err := ioutil.WriteFile(f.Name(), []byte(fileData), 644); err != nil {
+	if err := ioutil.WriteFile(f.Name(), []byte(fileData), 0644); err != nil {
 		return fmt.Errorf("failed to write file %s: %v", f.Name(), err)
 	}
 


### PR DESCRIPTION
Although sysbox-mgr will automatically add a "sysbox" entry to /etc/sub{g,u}id if it doesn't already exist, it failed to start when /etc/sub{g,u}id didn't exist with the following error in /var/log/sysbox-mgr.log:

failed to create sysbox-mgr: failed to setup subid allocator: error parsing file /etc/subuid: open /etc/subuid: no such file or directory

With this patch, /etc/sub{g,u}id will be created if it didn't already exist. (Apart from making the parser not fail if the file doesn't exist,  the permissions for the newly created file also needed to be corrected).

This is motivated by making sysbox easy to set up on Arch Linux. As far as I can tell, supported distributions already ship an empty /etc/sub{g,u}id.

PS: Other than this trivial issue I managed to get sysbox to work on Arch, there's another small annoyance which is that sysbox tries to find the kernel headers on `/usr/src/linux-headers-$(uname -r)` and Arch stores them in `/lib/modules/$(uname -r)/build`. Actually I think all mainstream distros store them there, but in some it's a symlink, so maybe the right approach is to always mount it there (resolving symlinks), or something similar. I may take a look but it's quite more involved to make that change without breaking something in the process.
