### PR TITLE
Fixes and improvements related to Linux Kernel header mounts on other Linux distros

### DIFF
--- a/mgr.go
+++ b/mgr.go
@@ -786,6 +786,9 @@ func (mgr *SysboxMgr) reqFsState(id, rootfs string) ([]configs.FsEntry, error) {
 		return nil, fmt.Errorf("container %s is not registered", formatter.ContainerID{id})
 	}
 
+	if len(mgr.linuxHeaderMounts) == 0 {
+		return nil, nil
+	}
 
 	// In certain scenarios a soft-link will be required to properly resolve the
 	// dependencies present in "/usr/src" and "/lib/modules/kernel" paths.

--- a/utils.go
+++ b/utils.go
@@ -475,6 +475,11 @@ func getLinuxHeaderMounts(kernelHdrPath string) ([]specs.Mount, error) {
 
 	var path = kernelHdrPath
 
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		logrus.Warnf("No kernel-headers found in host filesystem at %s. No headers will be mounted inside any of the containers.", kernelHdrPath)
+		return []specs.Mount{}, nil
+	}
+
 	// Create a mount-spec making use of the kernel-hdr-path in the host. This way,
 	// sys containers will have kernel-headers exposed in the same path utilized by
 	// the host. In addition to this, a softlink will be added to container's rootfs,

--- a/utils.go
+++ b/utils.go
@@ -622,13 +622,28 @@ func longestCommonPath(paths []string) string {
 	}
 
 	// find the first 'i' common characters between the shortest and longest paths
+	lcp := shortest
 	for i := 0; i < len(shortest) && i < len(longest); i++ {
 		if shortest[i] != longest[i] {
-			return shortest[:i]
+			lcp = shortest[:i]
+			break
 		}
 	}
 
-	return shortest
+	// if the longest common prefix does not end on a path separator, we may
+	// have left a path component truncated, and we need to strip it off
+	// (the longest common path of "/root/aba" and "/root/aca" is "/root/" and not "/root/a")
+	if !strings.HasSuffix(lcp, "/") {
+		// in the case we have something like "/root/a" and "/root/a/b", no need to strip "a" off
+		if (len(lcp) < len(shortest) && shortest[len(lcp)] != '/') ||
+		    (len(lcp) < len(longest) && longest[len(lcp)] != '/') {
+			if idx := strings.LastIndex(lcp, "/"); idx != -1 {
+				lcp = lcp[:idx]
+			}
+		}
+	}
+
+	return lcp
 }
 
 // returns a list of all symbolic links under the given directory


### PR DESCRIPTION
Those are various improvements related to Linux Kernel header mounts on other Linux distros, specially getting sysbox to work on Arch:

* Commit 1: Fix: longestCommonPath should not truncate a path component

This is just a fix for a very very low impact issue I found while manually testing various scenarios for Linux Kernel header mounts, as far as I know it does not have any impact on any supported configuration, but it's better to leave it fixed to avoid future issues with other distros.

* Commit 2: Create intermediate paths when symlinking Linux kernel headers

This fixes an issue launching containers which only happens on very obscure scenarios on supported/typical configurations, but which happens on Arch (after merging "Add Linux Kernel header path for Arch Linux" from sysbox-libs) when launching Alpine-based containers.

* Commit 3: Don't fail launching the containers on host kernel headers not found

This is a functional change to facilitate people getting basic Sysbox functionality to work on other distributions, if the kernel headers on the host can not be found, it is a warning instead of an error which prevents launching the containers.

I ran the test-mgr tests and they all passed.