### PR TITLE
fix: Use os.Stdout if no logging filename is given

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,8 +62,8 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "log, l",
-			Value: "/dev/stdout",
-			Usage: "log file path",
+			Value: "",
+			Usage: "log file path or empty string for stderr output (default: \"\")",
 		},
 		cli.StringFlag{
 			Name:  "log-level",
@@ -114,6 +114,8 @@ func main() {
 				return err
 			}
 			logrus.SetOutput(f)
+		} else {
+			logrus.SetOutput(os.Stderr)
 		}
 
 		if logFormat := ctx.GlobalString("log-format"); logFormat == "json" {


### PR DESCRIPTION
* Use os.Stderr if no logging filename is given
* Set default log to "" to enable stderr output
* This makes it possible to use journald by using default log value
* This solution is not optimal, but keeps backwards compatibility

Refs: https://github.com/nestybox/sysbox/issues/221
