### PR TITLE
Fix for sysbox issue #251.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/deckarep/golang-set v1.7.1
 	github.com/docker/docker v20.10.2+incompatible
 	github.com/fsnotify/fsnotify v1.4.7
+	github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531
 	github.com/karrick/godirwalk v1.16.1
 	github.com/mrunalp/fileutils v0.5.0
 	github.com/nestybox/sysbox-ipc v0.0.0-00010101000000-000000000000

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/deckarep/golang-set v1.7.1
 	github.com/docker/docker v20.10.2+incompatible
 	github.com/fsnotify/fsnotify v1.4.7
+	github.com/karrick/godirwalk v1.16.1
 	github.com/mrunalp/fileutils v0.5.0
 	github.com/nestybox/sysbox-ipc v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/dockerUtils v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
+github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531 h1:hgVxRoDDPtQE68PT4LFvNlPz2nBKd3OMlGKIQ69OmR4=
+github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531/go.mod h1:fqTUQpVYBvhCNIsMXGl2GE9q6z94DIP6NtFKXCSTVbg=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/idShiftUtils/idShiftUtils.go
+++ b/idShiftUtils/idShiftUtils.go
@@ -1,0 +1,113 @@
+//
+// Copyright 2019-2021 Nestybox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Utilities for shifting user and group IDs on the file system
+
+package idShiftUtils
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/karrick/godirwalk"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+type OffsetType int
+
+const (
+	OffsetAdd OffsetType = iota
+	OffsetSub
+)
+
+// "Shifts" ownership of user and group IDs on the given directory and files and directories
+// below it by the given offset, using chown.
+func ShiftIdsWithChown(baseDir string, uidOffset, gidOffset uint32, offsetDir OffsetType) error {
+
+	hardLinks := []uint64{}
+
+	err := godirwalk.Walk(baseDir, &godirwalk.Options{
+		Callback: func(path string, de *godirwalk.Dirent) error {
+			var targetUid, targetGid uint32
+
+			// When doing the chown, we don't follow symlinks as we want to change
+			// the ownership of the symlinks themselves. We will chown the
+			// symlink's target during the godirwalk (wunless the symlink is
+			// dangling in which case there is nothing to be done).
+
+			fi, err := os.Lstat(path)
+			if err != nil {
+				return err
+			}
+
+			st, ok := fi.Sys().(*syscall.Stat_t)
+			if !ok {
+				return fmt.Errorf("failed to convert to syscall.Stat_t")
+			}
+
+			// If a file has multiple hardlinks, change its ownership once
+			if st.Nlink >= 2 {
+				for _, linkInode := range hardLinks {
+					if linkInode == st.Ino {
+						return nil
+					}
+				}
+
+				hardLinks = append(hardLinks, st.Ino)
+			}
+
+			if offsetDir == OffsetAdd {
+				targetUid = st.Uid + uidOffset
+				targetGid = st.Gid + gidOffset
+			} else {
+				targetUid = st.Uid - uidOffset
+				targetGid = st.Gid - gidOffset
+			}
+
+			logrus.Debugf("chown %s from %d:%d to %d:%d", path, st.Uid, st.Gid, targetUid, targetGid)
+
+			err = unix.Lchown(path, int(targetUid), int(targetGid))
+			if err != nil {
+				return fmt.Errorf("chown %s to %d:%d failed: %s", path, targetUid, targetGid, err)
+			}
+
+			// TODO: deal with Linux ACL ownership
+
+			return nil
+		},
+
+		ErrorCallback: func(path string, err error) godirwalk.ErrorAction {
+
+			fi, err := os.Lstat(path)
+			if err != nil {
+				return godirwalk.Halt
+			}
+
+			// Ignore errors due to chown on dangling symlinks (they often occur in container image layers)
+			if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+				return godirwalk.SkipNode
+			}
+
+			return godirwalk.Halt
+		},
+
+		Unsorted: true, // Speeds up the directory tree walk
+	})
+
+	return err
+}

--- a/idShiftUtils/idShiftUtils.go
+++ b/idShiftUtils/idShiftUtils.go
@@ -156,7 +156,7 @@ func ShiftIdsWithChown(baseDir string, uidOffset, gidOffset uint32, offsetDir Of
 
 			// When doing the chown, we don't follow symlinks as we want to change
 			// the ownership of the symlinks themselves. We will chown the
-			// symlink's target during the godirwalk (wunless the symlink is
+			// symlink's target during the godirwalk (unless the symlink is
 			// dangling in which case there is nothing to be done).
 
 			fi, err := os.Lstat(path)

--- a/idShiftUtils/idShiftUtils_test.go
+++ b/idShiftUtils/idShiftUtils_test.go
@@ -1,0 +1,233 @@
+//
+// Copyright 2019-2021 Nestybox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Unit tests for idShiftUtils package
+
+package idShiftUtils
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	aclLib "github.com/joshlf/go-acl"
+)
+
+func TestShiftAclIds(t *testing.T) {
+
+	testDir, err := ioutil.TempDir("", "shiftAclTest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testDir)
+
+	// Access ACL to be set on testDir
+	aclUserEntry := aclLib.Entry{
+		Tag:       aclLib.TagUser,
+		Qualifier: "1001",
+		Perms:     7,
+	}
+
+	aclGroupEntry := aclLib.Entry{
+		Tag:       aclLib.TagGroup,
+		Qualifier: "1005",
+		Perms:     4,
+	}
+
+	aclMaskEntry := aclLib.Entry{
+		Tag:   aclLib.TagMask,
+		Perms: 7,
+	}
+
+	// Default ACL to be set on testDir
+	aclDef := aclLib.ACL{
+		aclLib.Entry{
+			Tag:   aclLib.TagUserObj,
+			Perms: 7,
+		},
+		aclLib.Entry{
+			Tag:   aclLib.TagGroupObj,
+			Perms: 0,
+		},
+		aclLib.Entry{
+			Tag:   aclLib.TagOther,
+			Perms: 0,
+		},
+		aclLib.Entry{
+			Tag:       aclLib.TagUser,
+			Qualifier: "1002",
+			Perms:     5,
+		},
+		aclLib.Entry{
+			Tag:       aclLib.TagGroup,
+			Qualifier: "1005",
+			Perms:     4,
+		},
+		aclLib.Entry{
+			Tag:   aclLib.TagMask,
+			Perms: 7,
+		},
+	}
+
+	acl, err := aclLib.Get(testDir)
+	if err != nil {
+		t.Fatalf("failed to get ACL on %s: %s", testDir, err)
+	}
+
+	acl = append(acl, aclUserEntry, aclGroupEntry, aclMaskEntry)
+
+	if err := aclLib.Set(testDir, acl); err != nil {
+		t.Fatalf("failed to set ACL %v on %s: %s", acl, testDir, err)
+	}
+
+	if err := aclLib.SetDefault(testDir, aclDef); err != nil {
+		t.Fatalf("failed to set default ACL %v on %s: %s", aclDef, testDir, err)
+	}
+
+	// ShiftAcls by subtracting offset
+
+	uidOffset := uint32(1000)
+	gidOffset := uint32(1000)
+
+	if err := shiftAclIds(testDir, true, uidOffset, gidOffset, OffsetSub); err != nil {
+		t.Fatalf("shiftAclIds() failed: %s", err)
+	}
+
+	// Verify the ACL for the dir were modified as expected
+	newAcl := aclLib.ACL{}
+	newDefAcl := aclLib.ACL{}
+
+	newAcl, err = aclLib.Get(testDir)
+	if err != nil {
+		t.Fatalf("failed to get ACL on %s: %s", testDir, err)
+	}
+
+	newDefAcl, err = aclLib.GetDefault(testDir)
+	if err != nil {
+		t.Fatalf("failed to get default ACL on %s: %s", testDir, err)
+	}
+
+	wantAclUserEntry := aclLib.Entry{
+		Tag:       aclLib.TagUser,
+		Qualifier: "1", // 1001 - 1000
+		Perms:     7,
+	}
+
+	wantAclGroupEntry := aclLib.Entry{
+		Tag:       aclLib.TagGroup,
+		Qualifier: "5", // 1005 - 1000
+		Perms:     4,
+	}
+
+	wantAclDefUserEntry := aclLib.Entry{
+		Tag:       aclLib.TagUser,
+		Qualifier: "2", // 1002 - 1000
+		Perms:     5,
+	}
+
+	wantAclDefGroupEntry := aclLib.Entry{
+		Tag:       aclLib.TagGroup,
+		Qualifier: "5", // 1005 - 1000
+		Perms:     4,
+	}
+
+	for _, e := range newAcl {
+		if e.Tag == aclLib.TagUser {
+			if e != wantAclUserEntry {
+				t.Logf("acl mismatch: want %v, got %v", wantAclUserEntry, e)
+			}
+		}
+		if e.Tag == aclLib.TagGroup {
+			if e != wantAclGroupEntry {
+				t.Logf("acl mismatch: want %v, got %v", wantAclGroupEntry, e)
+			}
+		}
+	}
+
+	for _, e := range newDefAcl {
+		if e.Tag == aclLib.TagUser {
+			if e != wantAclDefUserEntry {
+				t.Logf("acl mismatch: want %v, got %v", wantAclDefUserEntry, e)
+			}
+		}
+		if e.Tag == aclLib.TagGroup {
+			if e != wantAclDefGroupEntry {
+				t.Logf("acl mismatch: want %v, got %v", wantAclDefGroupEntry, e)
+			}
+		}
+	}
+
+	// ShiftAcls by adding offset (revert back to original value)
+
+	uidOffset = uint32(1000)
+	gidOffset = uint32(1000)
+
+	if err := shiftAclIds(testDir, true, uidOffset, gidOffset, OffsetAdd); err != nil {
+		t.Fatalf("shiftAclIds() failed: %s", err)
+	}
+
+	newAcl, err = aclLib.Get(testDir)
+	if err != nil {
+		t.Fatalf("failed to get ACL on %s: %s", testDir, err)
+	}
+
+	newDefAcl, err = aclLib.GetDefault(testDir)
+	if err != nil {
+		t.Fatalf("failed to get default ACL on %s: %s", testDir, err)
+	}
+
+	wantAclUserEntry = aclUserEntry
+	wantAclGroupEntry = aclGroupEntry
+
+	wantAclDefUserEntry = aclLib.Entry{
+		Tag:       aclLib.TagUser,
+		Qualifier: "1002",
+		Perms:     5,
+	}
+
+	wantAclDefGroupEntry = aclLib.Entry{
+		Tag:       aclLib.TagGroup,
+		Qualifier: "1005",
+		Perms:     4,
+	}
+
+	for _, e := range newAcl {
+		if e.Tag == aclLib.TagUser {
+			if e != wantAclUserEntry {
+				t.Logf("acl mismatch: want %v, got %v", wantAclUserEntry, e)
+			}
+		}
+		if e.Tag == aclLib.TagGroup {
+			if e != wantAclGroupEntry {
+				t.Logf("acl mismatch: want %v, got %v", wantAclGroupEntry, e)
+			}
+		}
+	}
+
+	for _, e := range newDefAcl {
+		if e.Tag == aclLib.TagUser {
+			if e != wantAclDefUserEntry {
+				t.Logf("acl mismatch: want %v, got %v", wantAclDefUserEntry, e)
+			}
+		}
+		if e.Tag == aclLib.TagGroup {
+			if e != wantAclDefGroupEntry {
+				t.Logf("acl mismatch: want %v, got %v", wantAclDefGroupEntry, e)
+			}
+		}
+	}
+
+}

--- a/mgr.go
+++ b/mgr.go
@@ -344,7 +344,7 @@ func (mgr *SysboxMgr) unregister(id string) error {
 		if revInfo.uidShifted {
 			logrus.Infof("reverting uid-shift on %s for %s", revInfo.path, formatter.ContainerID{id})
 
-			// revInfo.origUid is guaranteed to be higher than revInfo.targetUid
+			// revInfo.targetUid is guaranteed to be higher than revInfo.origUid
 			// (we checked in prepMounts())
 
 			uidOffset := revInfo.targetUid - revInfo.origUid

--- a/mgr.go
+++ b/mgr.go
@@ -31,6 +31,7 @@ import (
 	"github.com/nestybox/sysbox-libs/formatter"
 	libutils "github.com/nestybox/sysbox-libs/utils"
 	utils "github.com/nestybox/sysbox-libs/utils"
+	"github.com/nestybox/sysbox-mgr/idShiftUtils"
 	intf "github.com/nestybox/sysbox-mgr/intf"
 	"github.com/nestybox/sysbox-mgr/shiftfsMgr"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -349,7 +350,7 @@ func (mgr *SysboxMgr) unregister(id string) error {
 			uidOffset := revInfo.targetUid - revInfo.origUid
 			gidOffset := revInfo.targetGid - revInfo.origGid
 
-			if err = shiftUidsWithChown(revInfo.path, uidOffset, gidOffset, offsetSub); err != nil {
+			if err = idShiftUtils.ShiftIdsWithChown(revInfo.path, uidOffset, gidOffset, idShiftUtils.OffsetSub); err != nil {
 				logrus.Warnf("failed to revert uid-shift of mount source at %s: %s", revInfo.path, err)
 			}
 
@@ -692,7 +693,7 @@ func (mgr *SysboxMgr) prepMounts(id string, uid, gid uint32, shiftUids bool, pre
 				uidOffset := uid - origUid
 				gidOffset := gid - origGid
 
-				if err = shiftUidsWithChown(src, uidOffset, gidOffset, offsetAdd); err != nil {
+				if err = idShiftUtils.ShiftIdsWithChown(src, uidOffset, gidOffset, idShiftUtils.OffsetAdd); err != nil {
 					return fmt.Errorf("failed to shift uids via chown for mount source at %s: %s", src, err)
 				}
 

--- a/volMgr/volMgr.go
+++ b/volMgr/volMgr.go
@@ -282,15 +282,13 @@ func (m *vmgr) SyncOutAndDestroyAll() {
 	}
 }
 
-// rsyncVol performs an rsync from src to dest; if shiftUids is true, the rsync
-// "shiftfs" the ownership of files copied to dest by the given user and group
-// ID offsets.
+// rsyncVol performs an rsync from src to dest.
 //
-// Note that this can result in many file descriptors being opened by rsync,
-// which the kernel may account to sysbox-mgr. Thus, the file open limit for
-// sysbox-mgr should be very high / unlimited since the number of open files
-// depends on how much data there is to copy and how many containers are active
-// at a given time.
+// Note that depending no how much data is transferred, this operation can
+// result in many file descriptors being opened by rsync, which the kernel may
+// account to sysbox-mgr. Thus, the file open limit for sysbox-mgr should be
+// very high / unlimited since the number of open files depends on how much data
+// there is to copy and how many containers are active at a given time.
 func (m *vmgr) rsyncVol(src, dest string) error {
 
 	var cmd *exec.Cmd


### PR DESCRIPTION
This couple of changes provide a fix for Sysbox issue #251 by fixing the chown algorithm used by sysbox when moving data between a container's rootfs and a temporary cache setup by sysbox. 

Such data movement is performed by Sysbox when a container is created, to avoid certain directories inside the container from using overlayfs. During this data movement, user and group IDs may need to be "shifted" using chown. Prior to this change, the uid shifting algorithm was not quite right and failed to keep relative ownerships properly for files not owned by root inside the container.

These changes fix this.
