### PR TITLE
Fixes for container restarts (Linux kernel headers mounts + UID shifting)

### DIFF
--- a/mgr.go
+++ b/mgr.go
@@ -80,6 +80,7 @@ type containerInfo struct {
 	rootfs       string
 	mntPrepRev   []mntPrepRevInfo
 	mounts       []mountInfo
+	containerMnts []specs.Mount
 	uidInfo      uidInfo
 	shiftfsMarks []configs.ShiftfsMount
 	autoRemove   bool
@@ -520,11 +521,7 @@ func (mgr *SysboxMgr) reqMounts(id, rootfs string, uid, gid uint32, shiftUids bo
 
 	// if this is a stopped container that is being re-started, reuse its prior mounts
 	if info.state == restarted {
-		mounts := []specs.Mount{}
-		for _, mntInfo := range info.mounts {
-			mounts = append(mounts, mntInfo.mounts...)
-		}
-		return mounts, nil
+		return info.containerMnts, nil
 	}
 
 	// setup dirs that will be bind-mounted into container
@@ -576,6 +573,7 @@ func (mgr *SysboxMgr) reqMounts(id, rootfs string, uid, gid uint32, shiftUids bo
 	if len(mntInfos) > 0 {
 		info.rootfs = rootfs
 		info.mounts = mntInfos
+		info.containerMnts = containerMnts
 
 		mgr.ctLock.Lock()
 		mgr.contTable[id] = info

--- a/mgr.go
+++ b/mgr.go
@@ -360,6 +360,7 @@ func (mgr *SysboxMgr) unregister(id string) error {
 
 		mgr.exclMntTable.remove(revInfo.path, id)
 	}
+	info.mntPrepRev = []mntPrepRevInfo{}
 
 	mgr.ctLock.Lock()
 	mgr.contTable[id] = info


### PR DESCRIPTION
Two fixes related to container restarts (`docker stop` + `docker start`):

* Fix multiple UID shifts on special mounts when restarting a container (causes the source directory to eventually be assigned to the wrong owner)
* Fix Linux header mounts when restarting a container

See the commit messages for more details. The first problem is quite easy to run into when using docker-compose since `docker-compose up` + CTRL-C + `docker-compose up` will restart a container.

All tests OK (`make test-sysbox-shiftuid`).
