### PR TITLE
Capture special devices during inner Docker image preloading.

### DIFF
--- a/volMgr/volMgr.go
+++ b/volMgr/volMgr.go
@@ -307,13 +307,13 @@ func (m *vmgr) rsyncVol(src, dest string, uid, gid uint32, shiftUids bool, shift
 	srcDir := src + "/"
 
 	if usermap == "" && groupmap == "" {
-		cmd = exec.Command("rsync", "-rauqlH", "--no-specials", "--no-devices", "--delete", srcDir, dest)
+		cmd = exec.Command("rsync", "-rauqlH", "--no-devices", "--delete", srcDir, dest)
 	} else if usermap != "" && groupmap == "" {
-		cmd = exec.Command("rsync", "-rauqlH", "--no-specials", "--no-devices", "--delete", usermap, srcDir, dest)
+		cmd = exec.Command("rsync", "-rauqlH", "--no-devices", "--delete", usermap, srcDir, dest)
 	} else if usermap == "" && groupmap != "" {
-		cmd = exec.Command("rsync", "-rauqlH", "--no-specials", "--no-devices", "--delete", groupmap, srcDir, dest)
+		cmd = exec.Command("rsync", "-rauqlH", "--no-devices", "--delete", groupmap, srcDir, dest)
 	} else {
-		cmd = exec.Command("rsync", "-rauqlH", "--no-specials", "--no-devices", "--delete", usermap, groupmap, srcDir, dest)
+		cmd = exec.Command("rsync", "-rauqlH", "--no-devices", "--delete", usermap, groupmap, srcDir, dest)
 	}
 
 	cmd.Stdout = &output


### PR DESCRIPTION
Sysbox supports preloading of inner Docker images into a Sysbox
container, via a "docker build" or "docker commit".

However, there was a problem when the inner images being preloaded had
special devices in them (e.g., FIFOs and sockets). This problem led
to the preloaded images missing the special devices, causing problems
for applications that depended on these.

This commit fixes this.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>