### PR TITLE
Fix for issue preventing container init in userns-remap + shiftfs scenarios

### DIFF
--- a/shiftfsMgr/shiftfsMgr.go
+++ b/shiftfsMgr/shiftfsMgr.go
@@ -53,7 +53,7 @@ func New(sysboxLibDir string) (intf.ShiftfsMgr, error) {
 
 	workDir := filepath.Join(sysboxLibDir, "shiftfs")
 
-	if err := os.MkdirAll(workDir, 0700); err != nil {
+	if err := os.MkdirAll(workDir, 0710); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The following error is seen when attempting to create a sysbox container through the docker-cli when this one is configured in userns-remap mode:

```
root@sysbox-test:~/nestybox/sysbox# docker run --runtime=sysbox-runc -it --rm ubuntu:latest
Unable to find image 'ubuntu:latest' locally
latest: Pulling from library/ubuntu
16ec32c2132b: Pull complete
Digest: sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
Status: Downloaded newer image for ubuntu:latest
docker: Error response from daemon: OCI runtime create failed: container_linux.go:393: starting container process caused: process_linux.go:404: getting the final child's pid from pipe caused: EOF: unknown.
ERRO[0006] error waiting for container: context canceled
```

The error is observed if the setup meets all the following requirements:

- docker is configured in userns-remap mode
- shiftfs kernel module is present
- docker version is < 20.3

The fix is to make some adjustments to the permissions of the path where shiftfs components are bind-mounted during the sys-container initialization.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>