### PR TITLE
Modprobe configfs when starting Sysbox.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -778,6 +779,12 @@ func preFlightCheck() error {
 			return fmt.Errorf("%s is not installed on host.", prog)
 		}
 	}
+
+	// Required to allow dummy configfs folders to be exposed inside containers.
+	if err := exec.Command("modprobe", "configfs").Run(); err != nil {
+		return fmt.Errorf("failed to modprobe configfs: %s", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This is required so that mounting procfs inside sys containers creates a
configfs folder, on top of which Sysbox currently creates a dummy mount.

Typically the modprobe is done by the Sysbox package installer, but for
scenarios where Sysbox was installed in a different way (e.g., built from
source), the modprobe during Sysbox startup helps ensure configfs
is present.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>