### PR TITLE
Support for RKE2 within sys-containers (flannel cni)

### DIFF
--- a/mgr.go
+++ b/mgr.go
@@ -95,8 +95,9 @@ type SysboxMgr struct {
 	subidAlloc        intf.SubidAlloc
 	dockerVolMgr      intf.VolMgr
 	kubeletVolMgr     intf.VolMgr
-	k3sVolMgr         intf.VolMgr
 	k0sVolMgr         intf.VolMgr
+	k3sVolMgr         intf.VolMgr
+	rke2VolMgr        intf.VolMgr
 	containerdVolMgr  intf.VolMgr
 	shiftfsMgr        intf.ShiftfsMgr
 	hostDistro        string
@@ -152,14 +153,19 @@ func newSysboxMgr(ctx *cli.Context) (*SysboxMgr, error) {
 		return nil, fmt.Errorf("failed to setup kubelet vol mgr: %v", err)
 	}
 
+	k0sVolMgr, err := setupK0sVolMgr(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup k0s vol mgr: %v", err)
+	}
+
 	k3sVolMgr, err := setupK3sVolMgr(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup k3s vol mgr: %v", err)
 	}
 
-	k0sVolMgr, err := setupK0sVolMgr(ctx)
+	rke2VolMgr, err := setupRke2VolMgr(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to setup k0s vol mgr: %v", err)
+		return nil, fmt.Errorf("failed to setup rke2 vol mgr: %v", err)
 	}
 
 	containerdVolMgr, err := setupContainerdVolMgr(ctx)
@@ -214,8 +220,9 @@ func newSysboxMgr(ctx *cli.Context) (*SysboxMgr, error) {
 		subidAlloc:        subidAlloc,
 		dockerVolMgr:      dockerVolMgr,
 		kubeletVolMgr:     kubeletVolMgr,
-		k3sVolMgr:         k3sVolMgr,
 		k0sVolMgr:         k0sVolMgr,
+		k3sVolMgr:         k3sVolMgr,
+		rke2VolMgr:        rke2VolMgr,
 		containerdVolMgr:  containerdVolMgr,
 		shiftfsMgr:        shiftfsMgr,
 		hostDistro:        hostDistro,
@@ -288,8 +295,9 @@ func (mgr *SysboxMgr) Stop() error {
 
 	mgr.dockerVolMgr.SyncOutAndDestroyAll()
 	mgr.kubeletVolMgr.SyncOutAndDestroyAll()
-	mgr.k3sVolMgr.SyncOutAndDestroyAll()
 	mgr.k0sVolMgr.SyncOutAndDestroyAll()
+	mgr.k3sVolMgr.SyncOutAndDestroyAll()
+	mgr.rke2VolMgr.SyncOutAndDestroyAll()
 	mgr.containerdVolMgr.SyncOutAndDestroyAll()
 	mgr.shiftfsMgr.UnmarkAll()
 
@@ -571,10 +579,12 @@ func (mgr *SysboxMgr) volSyncOut(id string, info containerInfo) error {
 			err = mgr.dockerVolMgr.SyncOut(id)
 		case ipcLib.MntVarLibKubelet:
 			err = mgr.kubeletVolMgr.SyncOut(id)
-		case ipcLib.MntVarLibK3s:
-			err = mgr.k3sVolMgr.SyncOut(id)
 		case ipcLib.MntVarLibK0s:
 			err = mgr.k0sVolMgr.SyncOut(id)
+		case ipcLib.MntVarLibRancherK3s:
+			err = mgr.k3sVolMgr.SyncOut(id)
+		case ipcLib.MntVarLibRancherRke2:
+			err = mgr.rke2VolMgr.SyncOut(id)
 		case ipcLib.MntVarLibContainerdOvfs:
 			err = mgr.containerdVolMgr.SyncOut(id)
 		}
@@ -649,11 +659,14 @@ func (mgr *SysboxMgr) removeCont(id string) {
 		case ipcLib.MntVarLibKubelet:
 			err = mgr.kubeletVolMgr.DestroyVol(id)
 
-		case ipcLib.MntVarLibK3s:
-			err = mgr.k3sVolMgr.DestroyVol(id)
-
 		case ipcLib.MntVarLibK0s:
 			err = mgr.k0sVolMgr.DestroyVol(id)
+
+		case ipcLib.MntVarLibRancherK3s:
+			err = mgr.k3sVolMgr.DestroyVol(id)
+
+		case ipcLib.MntVarLibRancherRke2:
+			err = mgr.rke2VolMgr.DestroyVol(id)
 
 		case ipcLib.MntVarLibContainerdOvfs:
 			err = mgr.containerdVolMgr.DestroyVol(id)
@@ -709,11 +722,14 @@ func (mgr *SysboxMgr) reqMounts(id, rootfs string, uid, gid uint32, reqList []ip
 		case ipcLib.MntVarLibKubelet:
 			m, err = mgr.kubeletVolMgr.CreateVol(id, rootfs, req.Dest, uid, gid, req.ShiftUids, 0755)
 
-		case ipcLib.MntVarLibK3s:
-			m, err = mgr.k3sVolMgr.CreateVol(id, rootfs, req.Dest, uid, gid, req.ShiftUids, 0755)
-
 		case ipcLib.MntVarLibK0s:
 			m, err = mgr.k0sVolMgr.CreateVol(id, rootfs, req.Dest, uid, gid, req.ShiftUids, 0755)
+
+		case ipcLib.MntVarLibRancherK3s:
+			m, err = mgr.k3sVolMgr.CreateVol(id, rootfs, req.Dest, uid, gid, req.ShiftUids, 0755)
+
+		case ipcLib.MntVarLibRancherRke2:
+			m, err = mgr.rke2VolMgr.CreateVol(id, rootfs, req.Dest, uid, gid, req.ShiftUids, 0755)
 
 		case ipcLib.MntVarLibContainerdOvfs:
 			m, err = mgr.containerdVolMgr.CreateVol(id, rootfs, req.Dest, uid, gid, req.ShiftUids, 0700)
@@ -1063,11 +1079,14 @@ func (mgr *SysboxMgr) pause(id string) error {
 		case ipcLib.MntVarLibKubelet:
 			err = mgr.kubeletVolMgr.SyncOut(id)
 
-		case ipcLib.MntVarLibK3s:
-			err = mgr.k3sVolMgr.SyncOut(id)
-
 		case ipcLib.MntVarLibK0s:
 			err = mgr.k0sVolMgr.SyncOut(id)
+
+		case ipcLib.MntVarLibRancherK3s:
+			err = mgr.k3sVolMgr.SyncOut(id)
+
+		case ipcLib.MntVarLibRancherRke2:
+			err = mgr.rke2VolMgr.SyncOut(id)
 
 		case ipcLib.MntVarLibContainerdOvfs:
 			err = mgr.containerdVolMgr.SyncOut(id)


### PR DESCRIPTION
Our goal here is to support RKE2 for CNIs other than the default one (i.e. Canal), which is currently only supported in Sysbox-EE. These changes allow users to utilize RKE2 with traditional CNIs such as flannel, which is supported by Sysbox-CE.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>