### PR TITLE
Add --honor-caps config option to sysbox-mgr.

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,6 +114,10 @@ func main() {
 			Name:  "allow-trusted-xattr",
 			Usage: "Allows the overlayfs trusted.overlay.opaque xattr to be set inside all Sysbox containers; needed when running Docker inside Sysbox on hosts with kernel < 5.11. Causes Sysbox to trap the *xattr syscalls inside the container, slowing it down (default = true).",
 		},
+		cli.BoolFlag{
+			Name:  "honor-caps",
+			Usage: "Honor the container's process capabilities passed to Sysbox by the higher level container manager (e.g., Docker/containerd). Without this, Sysbox always gives the container's root user full capabilities and other users no capabilities to mimic a VM-like environment. Note that the container's capabilities are isolated from the host via the Linux user-namespace. (default = false).",
+		},
 	}
 
 	// show-version specialization.

--- a/mgr.go
+++ b/mgr.go
@@ -94,6 +94,7 @@ type mgrConfig struct {
 	noRootfsCloning   bool
 	ignoreSysfsChown  bool
 	allowTrustedXattr bool
+	honorCaps         bool
 }
 
 type SysboxMgr struct {
@@ -224,6 +225,7 @@ func newSysboxMgr(ctx *cli.Context) (*SysboxMgr, error) {
 		noRootfsCloning:   ctx.GlobalBool("disable-rootfs-cloning"),
 		ignoreSysfsChown:  ctx.GlobalBool("ignore-sysfs-chown"),
 		allowTrustedXattr: ctx.GlobalBoolT("allow-trusted-xattr"),
+		honorCaps:         ctx.GlobalBool("honor-caps"),
 	}
 
 	if !mgrCfg.aliasDns {
@@ -242,8 +244,12 @@ func newSysboxMgr(ctx *cli.Context) (*SysboxMgr, error) {
 		logrus.Info("Ignoring chown of /sys inside container.")
 	}
 
-	if mgrCfg.allowTrustedXattr {
-		logrus.Info("Allowing trusted.overlay.opaque inside container.")
+	if !mgrCfg.allowTrustedXattr {
+		logrus.Info("Disallowing trusted.overlay.opaque inside container.")
+	}
+
+	if mgrCfg.honorCaps {
+		logrus.Info("Honoring process capabilities in OCI spec.")
 	}
 
 	mgr := &SysboxMgr{
@@ -458,6 +464,7 @@ func (mgr *SysboxMgr) register(regInfo *ipcLib.RegistrationInfo) (*ipcLib.Contai
 		NoRootfsCloning:   mgr.mgrCfg.noRootfsCloning,
 		IgnoreSysfsChown:  mgr.mgrCfg.ignoreSysfsChown,
 		AllowTrustedXattr: mgr.mgrCfg.allowTrustedXattr,
+		HonorCaps:         mgr.mgrCfg.honorCaps,
 		Userns:            info.userns,
 		UidMappings:       info.uidMappings,
 		GidMappings:       info.gidMappings,


### PR DESCRIPTION
This option causes Sysbox to honor the process capabilities passed to it by the
higher level manager (e.g., Docker/containerd) via the container's OCI spec.
This provides a mechanism by which users can finely control the capabilities
given to the Sysbox container. The drawback is that users are now required
to understand which capabilities the programs running inside the container
need.

The option is disabled by default to keep Sysbox's existing behavior of
assigning root user processes all capabilities and non-root user processes no
capabilities within the container's user-namespace (so as to mimic a VM-like
environment). The default behavior makes it possible for Sysbox containers to
run system level software (e.g., systemd, Docker, Kubernetes, etc.) easily. Such
software typically require many Linux capabilities to operate correctly.

Note that the Sysbox container's user-namespace restricts those capabilities to
the container only (i.e., the container processes have no capabilities at host
level).

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>