### PR TITLE
Reduce mount table parsing for improved performance.

### DIFF
--- a/rootfsCloner/rootfsCloner.go
+++ b/rootfsCloner/rootfsCloner.go
@@ -79,7 +79,12 @@ func (c *cloner) CreateClone(id, origRootfs string) (string, error) {
 	}
 
 	// Get the mount info for the orig rootfs
-	origRootfsMntInfo, err := mount.GetMountAtPid(uint32(os.Getpid()), origRootfs)
+	allMounts, err := mount.GetMounts()
+	if err != nil {
+		return "", err
+	}
+
+	origRootfsMntInfo, err := mount.GetMountAt(origRootfs, allMounts)
 	if err != nil {
 		return "", fmt.Errorf("failed to get mount info for mount at %s: %s", origRootfs, err)
 	}

--- a/shiftfsMgr/shiftfsMgr.go
+++ b/shiftfsMgr/shiftfsMgr.go
@@ -35,6 +35,7 @@ import (
 	intf "github.com/nestybox/sysbox-mgr/intf"
 	"github.com/nestybox/sysbox-runc/libsysbox/shiftfs"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/mount"
 	"github.com/sirupsen/logrus"
 )
 
@@ -93,6 +94,11 @@ func (sm *mgr) Mark(id string, mountReqs []configs.ShiftfsMount, createMarkpoint
 
 	markpoints := []configs.ShiftfsMount{}
 
+	allMounts, err := mount.GetMounts()
+	if err != nil {
+		return nil, err
+	}
+
 	for _, mntReq := range mountReqs {
 
 		mntReqPath := mntReq.Source
@@ -117,7 +123,7 @@ func (sm *mgr) Mark(id string, mountReqs []configs.ShiftfsMount, createMarkpoint
 
 		// if shiftfs already marked, no action (some entity other than sysbox did the
 		// marking; we don't track that)
-		mounted, err := shiftfs.Mounted(mntReqPath)
+		mounted, err := shiftfs.Mounted(mntReqPath, allMounts)
 		if err != nil {
 			return nil, fmt.Errorf("error while checking for existing shiftfs mount on %s: %v", mntReqPath, err)
 		}


### PR DESCRIPTION
Prior to this change, sysbox-mgr was inadvertendly parsing the mount table
(i.e., obtained via /proc/self/mountinfo) multiple times during a container
startup. This change reduces this for improved performance.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>