### PR TITLE
sysbox-mgr: changes to enable ID-mapping of the container's rootfs and implicit mounts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/nestybox/sysbox-libs/formatter v0.0.0-20211230192847-357e78e444bd
 	github.com/nestybox/sysbox-libs/idShiftUtils v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/utils v0.0.0-00010101000000-000000000000
+	github.com/nestybox/sysbox-libs/mount v0.0.0-00010101000000-000000000000
+	github.com/nestybox/sysbox-libs/overlayUtils v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-runc v0.0.0-00010101000000-000000000000
 	github.com/opencontainers/runc v1.0.0-rc9.0.20210126000000-2be806d1391d
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d
@@ -32,6 +34,10 @@ replace github.com/nestybox/sysbox-libs/formatter => ../sysbox-libs/formatter
 replace github.com/nestybox/sysbox-libs/dockerUtils => ../sysbox-libs/dockerUtils
 
 replace github.com/nestybox/sysbox-libs/idShiftUtils => ../sysbox-libs/idShiftUtils
+
+replace github.com/nestybox/sysbox-libs/overlayUtils => ../sysbox-libs/overlayUtils
+
+replace github.com/nestybox/sysbox-libs/mount => ../sysbox-libs/mount
 
 replace github.com/nestybox/sysbox-libs/libseccomp-golang => ../sysbox-libs/libseccomp-golang
 

--- a/go.mod
+++ b/go.mod
@@ -10,39 +10,35 @@ require (
 	github.com/nestybox/sysbox-ipc v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/dockerUtils v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/formatter v0.0.0-20211230192847-357e78e444bd
+	github.com/nestybox/sysbox-libs/idMap v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/idShiftUtils v0.0.0-00010101000000-000000000000
-	github.com/nestybox/sysbox-libs/utils v0.0.0-00010101000000-000000000000
+	github.com/nestybox/sysbox-libs/linuxUtils v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/mount v0.0.0-00010101000000-000000000000
-	github.com/nestybox/sysbox-libs/overlayUtils v0.0.0-00010101000000-000000000000
+	github.com/nestybox/sysbox-libs/shiftfs v0.0.0-00010101000000-000000000000
+	github.com/nestybox/sysbox-libs/utils v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-runc v0.0.0-00010101000000-000000000000
 	github.com/opencontainers/runc v1.0.0-rc9.0.20210126000000-2be806d1391d
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d
 	github.com/pkg/profile v1.5.0
-	github.com/sirupsen/logrus v1.7.0
+	github.com/sirupsen/logrus v1.9.0
 	github.com/urfave/cli v1.22.1
-	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
 )
 
-replace github.com/nestybox/sysbox-ipc => ../sysbox-ipc
-
-replace github.com/nestybox/sysbox-runc => ../sysbox-runc
-
-replace github.com/nestybox/sysbox-libs/utils => ../sysbox-libs/utils
-
-replace github.com/nestybox/sysbox-libs/formatter => ../sysbox-libs/formatter
-
-replace github.com/nestybox/sysbox-libs/dockerUtils => ../sysbox-libs/dockerUtils
-
-replace github.com/nestybox/sysbox-libs/idShiftUtils => ../sysbox-libs/idShiftUtils
-
-replace github.com/nestybox/sysbox-libs/overlayUtils => ../sysbox-libs/overlayUtils
-
-replace github.com/nestybox/sysbox-libs/mount => ../sysbox-libs/mount
-
-replace github.com/nestybox/sysbox-libs/libseccomp-golang => ../sysbox-libs/libseccomp-golang
-
-replace github.com/nestybox/sysbox-libs/capability => ../sysbox-libs/capability
-
-replace github.com/opencontainers/runc => ./../sysbox-runc
-
-replace github.com/godbus/dbus => github.com/godbus/dbus/v5 v5.0.3
+replace (
+	github.com/nestybox/sysbox-ipc => ../sysbox-ipc
+	github.com/nestybox/sysbox-runc => ../sysbox-runc
+	github.com/nestybox/sysbox-libs/utils => ../sysbox-libs/utils
+	github.com/nestybox/sysbox-libs/formatter => ../sysbox-libs/formatter
+	github.com/nestybox/sysbox-libs/dockerUtils => ../sysbox-libs/dockerUtils
+	github.com/nestybox/sysbox-libs/idShiftUtils => ../sysbox-libs/idShiftUtils
+	github.com/nestybox/sysbox-libs/overlayUtils => ../sysbox-libs/overlayUtils
+	github.com/nestybox/sysbox-libs/linuxUtils => ../sysbox-libs/linuxUtils
+	github.com/nestybox/sysbox-libs/shiftfs => ../sysbox-libs/shiftfs
+	github.com/nestybox/sysbox-libs/mount => ../sysbox-libs/mount
+	github.com/nestybox/sysbox-libs/libseccomp-golang => ../sysbox-libs/libseccomp-golang
+	github.com/nestybox/sysbox-libs/capability => ../sysbox-libs/capability
+	github.com/nestybox/sysbox-libs/idMap => ../sysbox-libs/idMap
+	github.com/opencontainers/runc => ./../sysbox-runc
+	github.com/godbus/dbus => github.com/godbus/dbus/v5 v5.0.3
+)

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/nestybox/sysbox-libs/idMap v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/idShiftUtils v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/linuxUtils v0.0.0-00010101000000-000000000000
+	github.com/nestybox/sysbox-libs/overlayUtils v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/mount v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/shiftfs v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/utils v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,9 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
-github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/afero v1.4.1 h1:asw9sl74539yqavKaglDM5hFpdJVK0Y5Dr/JOgQ89nQ=
 github.com/spf13/afero v1.4.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -118,8 +119,9 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
@@ -167,11 +169,13 @@ golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201029080932-201ba4db2418/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
+golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 h1:Hir2P/De0WpUhtrKGGjvSb2YxUgyZ7EFOSLIcSSpiwE=
 golang.org/x/time v0.0.0-20201208040808-7e3f01d25324/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/main.go
+++ b/main.go
@@ -126,6 +126,10 @@ func main() {
 			Name:  "syscont-mode",
 			Usage: "Causes Sysbox to run in \"system container\" mode. In this mode, it sets up the container to run system workloads (e.g., systemd, Docker, Kubernetes, etc.) seamlessly and securely. When set to false, Sysbox operates in \"regular container\" mode where it sets up the container strictly per its OCI spec (usually for microservices), with the exception of the Linux 'user' and 'cgroup' namespaces which Sysbox always enables for extra container isolation. (default = true)",
 		},
+		cli.BoolFlag{
+			Name:  "fsuid-map-fail-on-error",
+			Usage: "When set to true, fail to launch a container whenever filesystem uid-mapping (needed for files to show proper ownership inside the container's user-namespace) hits an error; when set to false, launch the container anyway (files may show up owned by nobody:nogroup) (default = false).",
+		},
 	}
 
 	// show-version specialization.

--- a/main.go
+++ b/main.go
@@ -111,6 +111,10 @@ func main() {
 			Usage: "Disables Sysbox's rootfs cloning feature (used for fast chown of the container's rootfs in hosts without shiftfs); this option will significantly slow down container startup time in hosts without shiftfs (default = false)",
 		},
 		cli.BoolFlag{
+			Name:  "disable-ovfs-on-idmapped-mount",
+			Usage: "Disables ID-mapping of overlayfs (available in Linux kernel 5.19+); when set to true, forces Sysbox to use either shiftfs (if available on the host) or otherwise chown the container's rootfs, slowing container start/stop time; meant for testing (default = false)",
+		},
+		cli.BoolFlag{
 			Name:  "ignore-sysfs-chown",
 			Usage: "Ignore chown of /sys inside all Sysbox containers; may be needed to run a few apps that chown /sys inside the container (e.g,. rpm). Causes Sysbox to trap the chown syscall inside the container, slowing it down (default = false).",
 		},

--- a/mgr.go
+++ b/mgr.go
@@ -242,6 +242,10 @@ func newSysboxMgr(ctx *cli.Context) (*SysboxMgr, error) {
 		}
 	}
 
+	if ctx.GlobalBool("disable-ovfs-on-idmapped-mount") {
+		ovfsOnIDMapMountOk = false
+	}
+
 	shiftfsModPresent := false
 	shiftfsOk := false
 	shiftfsOnOvfsOk := false
@@ -291,6 +295,11 @@ func newSysboxMgr(ctx *cli.Context) (*SysboxMgr, error) {
 		logrus.Info("Use of ID-mapped mounts disabled.")
 	} else {
 		logrus.Infof("ID-mapped mounts supported by kernel: %s", ifThenElse(mgrCfg.idMapMountOk, "yes", "no"))
+	}
+
+	if ctx.GlobalBool("disable-ovfs-on-idmapped-mount") {
+		logrus.Info("Use of overlayfs on ID-mapped mounts disabled.")
+	} else {
 		logrus.Infof("Overlayfs on ID-mapped mounts supported by kernel: %s", ifThenElse(mgrCfg.overlayfsOnIDMapMountOk, "yes", "no"))
 	}
 

--- a/mgr.go
+++ b/mgr.go
@@ -94,6 +94,7 @@ type mgrConfig struct {
 	allowTrustedXattr       bool
 	honorCaps               bool
 	syscontMode             bool
+	fsuidMapFailOnErr       bool
 }
 
 type SysboxMgr struct {
@@ -267,6 +268,7 @@ func newSysboxMgr(ctx *cli.Context) (*SysboxMgr, error) {
 		allowTrustedXattr:       ctx.GlobalBoolT("allow-trusted-xattr"),
 		honorCaps:               ctx.GlobalBool("honor-caps"),
 		syscontMode:             ctx.GlobalBoolT("syscont-mode"),
+		fsuidMapFailOnErr:       ctx.GlobalBool("fsuid-map-fail-on-error"),
 	}
 
 	if !mgrCfg.aliasDns {
@@ -308,6 +310,10 @@ func newSysboxMgr(ctx *cli.Context) (*SysboxMgr, error) {
 		logrus.Info("Operating in system container mode.")
 	} else {
 		logrus.Info("Operating in regular container mode.")
+	}
+
+	if mgrCfg.fsuidMapFailOnErr {
+		logrus.Info("fsuid-map-fail-on-error = true.")
 	}
 
 	mgr := &SysboxMgr{
@@ -535,6 +541,7 @@ func (mgr *SysboxMgr) register(regInfo *ipcLib.RegistrationInfo) (*ipcLib.Contai
 		AllowTrustedXattr:       mgr.mgrCfg.allowTrustedXattr,
 		HonorCaps:               mgr.mgrCfg.honorCaps,
 		SyscontMode:             mgr.mgrCfg.syscontMode,
+		FsuidMapFailOnErr:       mgr.mgrCfg.fsuidMapFailOnErr,
 		Userns:                  info.userns,
 		UidMappings:             info.uidMappings,
 		GidMappings:             info.gidMappings,

--- a/mgr.go
+++ b/mgr.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nestybox/sysbox-libs/dockerUtils"
 	"github.com/nestybox/sysbox-libs/formatter"
 	"github.com/nestybox/sysbox-libs/idShiftUtils"
+	"github.com/nestybox/sysbox-libs/linuxUtils"
 	libutils "github.com/nestybox/sysbox-libs/utils"
 	intf "github.com/nestybox/sysbox-mgr/intf"
 	"github.com/nestybox/sysbox-mgr/rootfsCloner"
@@ -205,12 +206,12 @@ func newSysboxMgr(ctx *cli.Context) (*SysboxMgr, error) {
 		return nil, fmt.Errorf("failed to setup rootfs mgr: %v", err)
 	}
 
-	hostDistro, err := libutils.GetDistro()
+	hostDistro, err := linuxUtils.GetDistro()
 	if err != nil {
 		return nil, fmt.Errorf("failed to identify system's linux distribution: %v", err)
 	}
 
-	hostKernelHdrPath, err := libutils.GetLinuxHeaderPath(hostDistro)
+	hostKernelHdrPath, err := linuxUtils.GetLinuxHeaderPath(hostDistro)
 	if err != nil {
 		return nil, fmt.Errorf("failed to identify system's linux-header path: %v", err)
 	}
@@ -1152,7 +1153,7 @@ func (mgr *SysboxMgr) getKernelHeaderSoftlink(rootfs string) ([]configs.FsEntry,
 	// not returning any received error to ensure we complete container's
 	// registration in all scenarios (i.e. rootfs may not include a full linux
 	// env -- it may miss os-release file).
-	cntrDistro, err := libutils.GetDistroPath(rootfs)
+	cntrDistro, err := linuxUtils.GetDistroPath(rootfs)
 	if err != nil {
 		return nil, nil
 	}
@@ -1163,7 +1164,7 @@ func (mgr *SysboxMgr) getKernelHeaderSoftlink(rootfs string) ([]configs.FsEntry,
 	}
 
 	// Obtain container's kernel-header path.
-	cntrKernelPath, err := libutils.GetLinuxHeaderPath(cntrDistro)
+	cntrKernelPath, err := linuxUtils.GetLinuxHeaderPath(cntrDistro)
 	if err != nil {
 		return nil, fmt.Errorf("failed to identify kernel-header path of container's rootfs %s: %v",
 			rootfs, err)

--- a/mgr.go
+++ b/mgr.go
@@ -667,12 +667,17 @@ func (mgr *SysboxMgr) unregister(id string) error {
 		!info.autoRemove &&
 		info.rootfsUidShiftType == idShiftUtils.IDMappedMount {
 
-		rootfsOnOvfs, rootfsOvfsUpper, err := isRootfsOnOverlayfs(info.rootfs)
+		rootfsOnOvfs, err := isRootfsOnOverlayfs(info.rootfs)
 		if err != nil {
 			return err
 		}
 
 		if rootfsOnOvfs {
+			rootfsOvfsUpper, err := getRootfsOverlayUpperLayer(info.rootfs)
+			if err != nil {
+				return err
+			}
+
 			uidOffset := -int32(info.uidMappings[0].HostID)
 			gidOffset := -int32(info.gidMappings[0].HostID)
 
@@ -1311,11 +1316,16 @@ func (mgr *SysboxMgr) pause(id string) error {
 	if info.rootfsUidShiftType == idShiftUtils.IDMappedMount &&
 		!info.rootfsOvfsUpperChowned {
 
-		rootfsOnOvfs, rootfsOvfsUpper, err := isRootfsOnOverlayfs(info.rootfs)
+		rootfsOnOvfs, err := isRootfsOnOverlayfs(info.rootfs)
 		if err != nil {
 			return err
 		}
 		if rootfsOnOvfs {
+			rootfsOvfsUpper, err := getRootfsOverlayUpperLayer(info.rootfs)
+			if err != nil {
+				return err
+			}
+
 			uidOffset := -int32(info.uidMappings[0].HostID)
 			gidOffset := -int32(info.gidMappings[0].HostID)
 

--- a/mgr.go
+++ b/mgr.go
@@ -707,7 +707,7 @@ func (mgr *SysboxMgr) unregister(id string) error {
 }
 
 func (mgr *SysboxMgr) volSyncOut(id string, info containerInfo) error {
-	var err error
+	var err, err2 error
 	failedVols := []string{}
 
 	for _, mnt := range info.reqMntInfos {
@@ -730,11 +730,12 @@ func (mgr *SysboxMgr) volSyncOut(id string, info containerInfo) error {
 
 		if err != nil {
 			failedVols = append(failedVols, mnt.kind.String())
+			err2 = err
 		}
 	}
 
 	if len(failedVols) > 0 {
-		return fmt.Errorf("sync-out for volume backing %s failed: %v", failedVols, err)
+		return fmt.Errorf("sync-out for volume backing %s: %v", failedVols, err2)
 	}
 
 	return nil

--- a/mgr.go
+++ b/mgr.go
@@ -845,7 +845,7 @@ func (mgr *SysboxMgr) reqMounts(id string, uid, gid uint32, reqList []ipcLib.Mou
 		return info.containerMnts, nil
 	}
 
-	// setup dirs that will be bind-mounted into container
+	// setup dirs that will be bind-mounted into the container
 	containerMnts := []specs.Mount{}
 	reqMntInfos := []mountInfo{}
 	rootfs := info.rootfs

--- a/rootfsCloner/rootfsCloner.go
+++ b/rootfsCloner/rootfsCloner.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 
 	"github.com/nestybox/sysbox-libs/formatter"
-	"github.com/nestybox/sysbox-runc/libcontainer/mount"
+	"github.com/nestybox/sysbox-libs/mount"
 	"github.com/sirupsen/logrus"
 )
 

--- a/rootfsCloner/utils.go
+++ b/rootfsCloner/utils.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	mapset "github.com/deckarep/golang-set"
-	"github.com/nestybox/sysbox-runc/libcontainer/mount"
+	"github.com/nestybox/sysbox-libs/mount"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 

--- a/shiftfsMgr/shiftfsMgr.go
+++ b/shiftfsMgr/shiftfsMgr.go
@@ -33,8 +33,8 @@ import (
 	uuid "github.com/google/uuid"
 	"github.com/nestybox/sysbox-libs/formatter"
 	"github.com/nestybox/sysbox-libs/mount"
+	"github.com/nestybox/sysbox-libs/shiftfs"
 	intf "github.com/nestybox/sysbox-mgr/intf"
-	"github.com/nestybox/sysbox-runc/libsysbox/shiftfs"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/sirupsen/logrus"
 )

--- a/shiftfsMgr/shiftfsMgr.go
+++ b/shiftfsMgr/shiftfsMgr.go
@@ -32,10 +32,10 @@ import (
 
 	uuid "github.com/google/uuid"
 	"github.com/nestybox/sysbox-libs/formatter"
+	"github.com/nestybox/sysbox-libs/mount"
 	intf "github.com/nestybox/sysbox-mgr/intf"
 	"github.com/nestybox/sysbox-runc/libsysbox/shiftfs"
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/opencontainers/runc/libcontainer/mount"
 	"github.com/sirupsen/logrus"
 )
 

--- a/shiftfsMgr/shiftfsMgr_test.go
+++ b/shiftfsMgr/shiftfsMgr_test.go
@@ -17,6 +17,7 @@
 package shiftfsMgr
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -35,12 +36,20 @@ type mountTest struct {
 	mounts []configs.ShiftfsMount
 }
 
-func hostSupportsShiftfs() bool {
-	modSupported, err := utils.KernelModSupported("shiftfs")
+func hostSupportsShiftfs() (bool, error) {
+
+	dir, err := ioutil.TempDir("/mnt/scratch", "shiftfsMgrTest")
 	if err != nil {
-		return false
+		return false, err
 	}
-	return modSupported
+	defer os.RemoveAll(dir)
+
+	shiftfsOk, err := shiftfs.ShiftfsSupported(dir)
+	if err != nil {
+		return false, fmt.Errorf("failed to check kernel shiftfs support: %v", err)
+	}
+
+	return shiftfsOk, nil
 }
 
 func setupTest() (string, error) {
@@ -97,7 +106,12 @@ func mountTestEqual(a, b []mountTest) bool {
 
 func TestShiftfsMgrBasic(t *testing.T) {
 
-	if !hostSupportsShiftfs() {
+	shiftfsOk, err := hostSupportsShiftfs()
+	if err != nil {
+		t.Errorf("error: host shiftfs check failed: %s", err)
+	}
+
+	if !shiftfsOk {
 		t.Skip("skipping test (shiftfs not supported).")
 	}
 
@@ -242,7 +256,12 @@ func TestShiftfsMgrBasic(t *testing.T) {
 
 func TestShiftfsMgrCreateMarkpoint(t *testing.T) {
 
-	if !hostSupportsShiftfs() {
+	shiftfsOk, err := hostSupportsShiftfs()
+	if err != nil {
+		t.Errorf("error: host shiftfs check failed: %s", err)
+	}
+
+	if !shiftfsOk {
 		t.Skip("skipping test (shiftfs not supported).")
 	}
 
@@ -386,7 +405,12 @@ func TestShiftfsMgrCreateMarkpoint(t *testing.T) {
 
 func TestShiftfsMgrMarkIgnore(t *testing.T) {
 
-	if !hostSupportsShiftfs() {
+	shiftfsOk, err := hostSupportsShiftfs()
+	if err != nil {
+		t.Errorf("error: host shiftfs check failed: %s", err)
+	}
+
+	if !shiftfsOk {
 		t.Skip("skipping test (shiftfs not supported).")
 	}
 
@@ -511,7 +535,12 @@ func TestShiftfsMgrMarkIgnore(t *testing.T) {
 
 func TestShiftfsMgrUnmarkAll(t *testing.T) {
 
-	if !hostSupportsShiftfs() {
+	shiftfsOk, err := hostSupportsShiftfs()
+	if err != nil {
+		t.Errorf("error: host shiftfs check failed: %s", err)
+	}
+
+	if !shiftfsOk {
 		t.Skip("skipping test (shiftfs not supported).")
 	}
 

--- a/shiftfsMgr/shiftfsMgr_test.go
+++ b/shiftfsMgr/shiftfsMgr_test.go
@@ -22,10 +22,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/nestybox/sysbox-libs/mount"
 	utils "github.com/nestybox/sysbox-libs/utils"
 	"github.com/nestybox/sysbox-runc/libsysbox/shiftfs"
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/opencontainers/runc/libcontainer/mount"
 )
 
 var sysboxLibDir string = "/var/lib/sysbox"

--- a/shiftfsMgr/shiftfsMgr_test.go
+++ b/shiftfsMgr/shiftfsMgr_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 
 	"github.com/nestybox/sysbox-libs/mount"
+	"github.com/nestybox/sysbox-libs/shiftfs"
 	utils "github.com/nestybox/sysbox-libs/utils"
-	"github.com/nestybox/sysbox-runc/libsysbox/shiftfs"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 

--- a/utils.go
+++ b/utils.go
@@ -868,28 +868,28 @@ func getInode(file string) (uint64, error) {
 	return st.Ino, nil
 }
 
-func checkIDMappingSupport(ctx *cli.Context) (bool, bool, error) {
-	useIDMapping, err := idMap.IDMapMountSupported(sysboxLibDir)
+func checkIDMapMountSupport(ctx *cli.Context) (bool, bool, error) {
+	IDMapMountOk, err := idMap.IDMapMountSupported(sysboxLibDir)
 	if err != nil {
 		return false, false, fmt.Errorf("failed to check kernel ID-mapping support: %v", err)
 	}
-	useIDMappingOnOvfs, err := idMap.IDMapMountSupportedOnOverlayfs(sysboxLibDir)
+	ovfsOnIDMapMountOk, err := idMap.OverlayfsOnIDMapMountSupported(sysboxLibDir)
 	if err != nil {
 		return false, false, fmt.Errorf("failed to check kernel ID-mapping-on-overlayfs support: %v", err)
 	}
-	return useIDMapping, useIDMappingOnOvfs, nil
+	return IDMapMountOk, ovfsOnIDMapMountOk, nil
 }
 
 func checkShiftfsSupport(ctx *cli.Context) (bool, bool, error) {
-	useShiftfs, err := shiftfs.ShiftfsSupported(sysboxLibDir)
+	shiftfsOk, err := shiftfs.ShiftfsSupported(sysboxLibDir)
 	if err != nil {
 		return false, false, fmt.Errorf("failed to check kernel shiftfs support: %v", err)
 	}
-	useShiftfsOnOvfs, err := shiftfs.ShiftfsSupportedOnOverlayfs(sysboxLibDir)
+	shiftfsOnOvfsOk, err := shiftfs.ShiftfsSupportedOnOverlayfs(sysboxLibDir)
 	if err != nil {
 		return false, false, fmt.Errorf("failed to check kernel shiftfs-on-overlayfs support: %v", err)
 	}
-	return useShiftfs, useShiftfsOnOvfs, nil
+	return shiftfsOk, shiftfsOnOvfsOk, nil
 }
 
 // ifThenElse is one-liner for "condition? a : b"

--- a/utils.go
+++ b/utils.go
@@ -893,30 +893,30 @@ func checkShiftfsSupport(ctx *cli.Context) (bool, bool, error) {
 	return shiftfsOk, shiftfsOnOvfsOk, nil
 }
 
-func isRootfsOnOverlayfs(rootfs string) (bool, string, error) {
+func isRootfsOnOverlayfs(rootfs string) (bool, error) {
 	fsName, err := libutils.GetFsName(rootfs)
 	if err != nil {
-		return false, "", err
+		return false, err
 	}
 	if fsName != "overlayfs" {
-		return false, "", nil
+		return false, nil
 	}
+	return true, nil
+}
 
+func getRootfsOverlayUpperLayer(rootfs string) (string, error) {
 	mounts, err := mount.GetMountsPid(uint32(os.Getpid()))
 	if err != nil {
-		return false, "", err
+		return "", err
 	}
-
-	// If the rootfs is not a mountpoint, return false.
 	mi, err := mount.GetMountAt(rootfs, mounts)
 	if err != nil {
-		return false, "", nil
+		return "", nil
 	}
-
 	ovfsMntOpts := overlayUtils.GetMountOpt(mi)
 	ovfsUpperLayer := overlayUtils.GetUpperLayer(ovfsMntOpts)
 
-	return true, ovfsUpperLayer, nil
+	return ovfsUpperLayer, nil
 }
 
 // ifThenElse is one-liner for "condition? a : b"

--- a/utils.go
+++ b/utils.go
@@ -30,10 +30,10 @@ import (
 	"syscall"
 
 	"github.com/nestybox/sysbox-libs/dockerUtils"
-	"github.com/nestybox/sysbox-libs/idShiftUtils"
+	"github.com/nestybox/sysbox-libs/idMap"
+	"github.com/nestybox/sysbox-libs/linuxUtils"
 	"github.com/nestybox/sysbox-libs/mount"
 	libutils "github.com/nestybox/sysbox-libs/utils"
-	utils "github.com/nestybox/sysbox-libs/utils"
 	intf "github.com/nestybox/sysbox-mgr/intf"
 	"github.com/nestybox/sysbox-mgr/subidAlloc"
 	"github.com/nestybox/sysbox-mgr/volMgr"
@@ -82,7 +82,7 @@ func (t *exclusiveMntTable) remove(mntSrc, containerId string) {
 		return
 	}
 
-	cids = utils.StringSliceRemove(cids, []string{containerId})
+	cids = libutils.StringSliceRemove(cids, []string{containerId})
 
 	if len(cids) > 0 {
 		t.mounts[mntSrc] = cids
@@ -602,7 +602,7 @@ func getLinuxHeaderMounts(kernelHdrPath string) ([]specs.Mount, error) {
 // getLibModMount returns a list of read-only mounts for the host's kernel modules dir (/lib/modules/<kernel-release>).
 func getLibModMounts() ([]specs.Mount, error) {
 
-	kernelRel, err := libutils.GetKernelRelease()
+	kernelRel, err := linuxUtils.GetKernelRelease()
 	if err != nil {
 		return nil, err
 	}
@@ -667,7 +667,7 @@ func createMountSpec(
 		// apply symlink filtering
 		for _, filt := range symlinkFilt {
 			filt = filepath.Clean(filt)
-			filtLinks := utils.StringSliceRemoveMatch(links, func(s string) bool {
+			filtLinks := libutils.StringSliceRemoveMatch(links, func(s string) bool {
 				if strings.HasPrefix(s, filt+"/") {
 					return false
 				}
@@ -874,11 +874,11 @@ func getIDMappingSupport(ctx *cli.Context) (bool, error) {
 		return false, nil
 	}
 
-	return libutils.KernelSupportsIDMappedMounts()
+	return linuxUtils.KernelSupportsIDMappedMounts()
 }
 
 func getIDMappingOvfsSupport() (bool, error) {
-	return idShiftUtils.IDMapMountSupportedOnOverlayfs(sysboxLibDir)
+	return idMap.IDMapMountSupportedOnOverlayfs(sysboxLibDir)
 }
 
 func getShiftfsSupport(ctx *cli.Context) (bool, error) {
@@ -888,5 +888,5 @@ func getShiftfsSupport(ctx *cli.Context) (bool, error) {
 		return false, nil
 	}
 
-	return libutils.KernelModSupported("shiftfs")
+	return linuxUtils.KernelModSupported("shiftfs")
 }

--- a/utils.go
+++ b/utils.go
@@ -30,12 +30,13 @@ import (
 	"syscall"
 
 	"github.com/nestybox/sysbox-libs/dockerUtils"
+	"github.com/nestybox/sysbox-libs/idShiftUtils"
+	"github.com/nestybox/sysbox-libs/mount"
 	libutils "github.com/nestybox/sysbox-libs/utils"
 	utils "github.com/nestybox/sysbox-libs/utils"
 	intf "github.com/nestybox/sysbox-mgr/intf"
 	"github.com/nestybox/sysbox-mgr/subidAlloc"
 	"github.com/nestybox/sysbox-mgr/volMgr"
-	"github.com/opencontainers/runc/libcontainer/mount"
 	"github.com/opencontainers/runc/libcontainer/user"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -864,4 +865,28 @@ func getInode(file string) (uint64, error) {
 	}
 
 	return st.Ino, nil
+}
+
+func getIDMappingSupport(ctx *cli.Context) (bool, error) {
+	disableIDMapping := ctx.GlobalBool("disable-idmapped-mount")
+
+	if disableIDMapping {
+		return false, nil
+	}
+
+	return libutils.KernelSupportsIDMappedMounts()
+}
+
+func getIDMappingOvfsSupport() (bool, error) {
+	return idShiftUtils.IDMapMountSupportedOnOverlayfs(sysboxLibDir)
+}
+
+func getShiftfsSupport(ctx *cli.Context) (bool, error) {
+	disableShiftfs := ctx.GlobalBool("disable-shiftfs")
+
+	if disableShiftfs {
+		return false, nil
+	}
+
+	return libutils.KernelModSupported("shiftfs")
 }

--- a/volMgr/volMgr.go
+++ b/volMgr/volMgr.go
@@ -400,9 +400,10 @@ func isRootfsOnOverlayfs(rootfs string) (bool, string, error) {
 		return false, "", err
 	}
 
+	// If the rootfs is not a mountpoint, return false.
 	mi, err := mount.GetMountAt(rootfs, mounts)
 	if err != nil {
-		return false, "", err
+		return false, "", nil
 	}
 
 	ovfsMntOpts := overlayUtils.GetMountOpt(mi)

--- a/volMgr/volMgr.go
+++ b/volMgr/volMgr.go
@@ -147,11 +147,9 @@ func (m *vmgr) CreateVol(id, rootfs, mountpoint string, uid, gid uint32, shiftUi
 		return nil, fmt.Errorf("failed to create volume for container %v: %v", id, err)
 	}
 
-	if shiftUids {
-		if err = os.Chown(volPath, int(uid), int(gid)); err != nil {
-			os.RemoveAll(volPath)
-			return nil, fmt.Errorf("failed to set ownership of volume %v: %v", volPath, err)
-		}
+	if err = os.Chown(volPath, int(uid), int(gid)); err != nil {
+		os.RemoveAll(volPath)
+		return nil, fmt.Errorf("failed to set ownership of volume %v: %v", volPath, err)
 	}
 
 	if m.sync {

--- a/volMgr/volMgr.go
+++ b/volMgr/volMgr.go
@@ -123,13 +123,11 @@ func (m *vmgr) CreateVol(id, rootfs, mountpoint string, uid, gid uint32, shiftUi
 		return nil, fmt.Errorf("failed to create volume for container %v: %v", id, err)
 	}
 
-	// Set the ownership of the newly created volume to match the given uid(gid); this
-	// ensures that the container will have permission to access the volume. Note that by
-	// doing this, we also ensure that sysbox-runc won't mount shiftfs on top of the
-	// volume.
-	if err = os.Chown(volPath, int(uid), int(gid)); err != nil {
-		os.RemoveAll(volPath)
-		return nil, fmt.Errorf("failed to set ownership of volume %v: %v", volPath, err)
+	if shiftUids {
+		if err = os.Chown(volPath, int(uid), int(gid)); err != nil {
+			os.RemoveAll(volPath)
+			return nil, fmt.Errorf("failed to set ownership of volume %v: %v", volPath, err)
+		}
 	}
 
 	if m.sync {


### PR DESCRIPTION
In kernel 5.19+, overlayfs can be mapped over ID-mapped mounts, which means Sysbox can now ID-map the container's rootfs as well as implicit volumes mounted into the container's `/var/lib/docker`, `/var/lib/kubelet`, and similar dirs where overlayfs will be moutned. This in turn removes or reduces the need to chown the container's rootfs and implicit volumes in hosts where shiftfs is not present.

The commits in this PR enable sysbox-mgr to support this.