### PR TITLE
Add --disable-inner-image-preload flag to sysbox-mgr.

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,6 +115,10 @@ func main() {
 			Usage: "Disables ID-mapping of overlayfs (available in Linux kernel 5.19+); when set to true, forces Sysbox to use either shiftfs (if available on the host) or otherwise chown the container's rootfs, slowing container start/stop time; meant for testing (default = false)",
 		},
 		cli.BoolFlag{
+			Name:  "disable-inner-image-preload",
+			Usage: "Disables the Sysbox feature that allows users to preload inner container images into system container images (e.g., via Docker commit or build); this makes container start/stop faster (default = false)",
+		},
+		cli.BoolFlag{
 			Name:  "ignore-sysfs-chown",
 			Usage: "Ignore chown of /sys inside all Sysbox containers; may be needed to run a few apps that chown /sys inside the container (e.g,. rpm). Causes Sysbox to trap the chown syscall inside the container, slowing it down (default = false).",
 		},

--- a/utils.go
+++ b/utils.go
@@ -284,7 +284,7 @@ func setupSubidAlloc(ctx *cli.Context) (intf.SubidAlloc, error) {
 	return subidAlloc, nil
 }
 
-func setupDockerVolMgr(ctx *cli.Context) (intf.VolMgr, error) {
+func setupDockerVolMgr(syncToRootfs bool) (intf.VolMgr, error) {
 	var statfs syscall.Statfs_t
 
 	hostDir := filepath.Join(sysboxLibDir, "docker")
@@ -312,10 +312,10 @@ func setupDockerVolMgr(ctx *cli.Context) (intf.VolMgr, error) {
 		}
 	}
 
-	return volMgr.New("dockerVolMgr", hostDir, true)
+	return volMgr.New("dockerVolMgr", hostDir, syncToRootfs)
 }
 
-func setupKubeletVolMgr(ctx *cli.Context) (intf.VolMgr, error) {
+func setupKubeletVolMgr(syncToRootfs bool) (intf.VolMgr, error) {
 
 	var statfs syscall.Statfs_t
 
@@ -341,10 +341,10 @@ func setupKubeletVolMgr(ctx *cli.Context) (intf.VolMgr, error) {
 		}
 	}
 
-	return volMgr.New("kubeletVolMgr", hostDir, true)
+	return volMgr.New("kubeletVolMgr", hostDir, syncToRootfs)
 }
 
-func setupK0sVolMgr(ctx *cli.Context) (intf.VolMgr, error) {
+func setupK0sVolMgr(syncToRootfs bool) (intf.VolMgr, error) {
 
 	var statfs syscall.Statfs_t
 
@@ -370,10 +370,10 @@ func setupK0sVolMgr(ctx *cli.Context) (intf.VolMgr, error) {
 		}
 	}
 
-	return volMgr.New("k0sVolMgr", hostDir, true)
+	return volMgr.New("k0sVolMgr", hostDir, syncToRootfs)
 }
 
-func setupK3sVolMgr(ctx *cli.Context) (intf.VolMgr, error) {
+func setupK3sVolMgr(syncToRootfs bool) (intf.VolMgr, error) {
 
 	var statfs syscall.Statfs_t
 
@@ -399,10 +399,10 @@ func setupK3sVolMgr(ctx *cli.Context) (intf.VolMgr, error) {
 		}
 	}
 
-	return volMgr.New("k3sVolMgr", hostDir, true)
+	return volMgr.New("k3sVolMgr", hostDir, syncToRootfs)
 }
 
-func setupRke2VolMgr(ctx *cli.Context) (intf.VolMgr, error) {
+func setupRke2VolMgr(syncToRootfs bool) (intf.VolMgr, error) {
 
 	var statfs syscall.Statfs_t
 
@@ -428,10 +428,10 @@ func setupRke2VolMgr(ctx *cli.Context) (intf.VolMgr, error) {
 		}
 	}
 
-	return volMgr.New("rke2VolMgr", hostDir, true)
+	return volMgr.New("rke2VolMgr", hostDir, syncToRootfs)
 }
 
-func setupBuildkitVolMgr(ctx *cli.Context) (intf.VolMgr, error) {
+func setupBuildkitVolMgr(syncToRootfs bool) (intf.VolMgr, error) {
 
 	var statfs syscall.Statfs_t
 
@@ -457,10 +457,10 @@ func setupBuildkitVolMgr(ctx *cli.Context) (intf.VolMgr, error) {
 		}
 	}
 
-	return volMgr.New("buildkitVolMgr", hostDir, true)
+	return volMgr.New("buildkitVolMgr", hostDir, syncToRootfs)
 }
 
-func setupContainerdVolMgr(ctx *cli.Context) (intf.VolMgr, error) {
+func setupContainerdVolMgr(syncToRootfs bool) (intf.VolMgr, error) {
 
 	var statfs syscall.Statfs_t
 
@@ -487,7 +487,7 @@ func setupContainerdVolMgr(ctx *cli.Context) (intf.VolMgr, error) {
 		}
 	}
 
-	return volMgr.New("containerdVolMgr", hostDir, true)
+	return volMgr.New("containerdVolMgr", hostDir, syncToRootfs)
 }
 
 func setupRunDir() error {


### PR DESCRIPTION
This flag disables the Sysbox feature that allows for preloading of inner container images into a Sysbox container (e.g., via Docker commit or build), or for running containers that come preloaded with inner images.

While the image preloading feature is useful in some cases, it increases the amount of time to start or stop a container. The increase can be significant in scenarios where Docker or K8s runs inside the Sysbox container and pulls many inner images (or heavy inner images).

By setting --disable-inner-image-preload, users can avoid slowing down container start/stop time, at the cost of loosing the feature that allows for inner Docker image preloading. This trade-off is useful for many users, particularly since most users don't use inner image preloading.

Note: in the future we may offer a way to set this per-container (as opposed to globally via the --disable-inner-image-preload flag).