### PR TITLE
Disable trusted xattr syscalls inside Sysbox containers by default.

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,9 +130,9 @@ func main() {
 			Name:  "ignore-sysfs-chown",
 			Usage: "Ignore chown of /sys inside all Sysbox containers; may be needed to run a few apps that chown /sys inside the container (e.g,. rpm). Causes Sysbox to trap the chown syscall inside the container, slowing it down (default = false).",
 		},
-		cli.BoolTFlag{
+		cli.BoolFlag{
 			Name:  "allow-trusted-xattr",
-			Usage: "Allows the overlayfs trusted.overlay.opaque xattr to be set inside all Sysbox containers; needed when running Docker inside Sysbox on hosts with kernel < 5.11. Causes Sysbox to trap the *xattr syscalls inside the container, slowing it down (default = true).",
+			Usage: "Allows the overlayfs trusted.overlay.opaque xattr to be set inside all Sysbox containers; needed when running Docker inside Sysbox on hosts with kernel < 5.11. Causes Sysbox to trap the *xattr syscalls inside the container, slowing it down (default = false).",
 		},
 		cli.BoolFlag{
 			Name:  "honor-caps",

--- a/mgr.go
+++ b/mgr.go
@@ -282,7 +282,7 @@ func newSysboxMgr(ctx *cli.Context) (*SysboxMgr, error) {
 		overlayfsOnIDMapMountOk: ovfsOnIDMapMountOk,
 		noRootfsCloning:         ctx.GlobalBool("disable-rootfs-cloning"),
 		ignoreSysfsChown:        ctx.GlobalBool("ignore-sysfs-chown"),
-		allowTrustedXattr:       ctx.GlobalBoolT("allow-trusted-xattr"),
+		allowTrustedXattr:       ctx.GlobalBool("allow-trusted-xattr"),
 		honorCaps:               ctx.GlobalBool("honor-caps"),
 		syscontMode:             ctx.GlobalBoolT("syscont-mode"),
 		fsuidMapFailOnErr:       ctx.GlobalBool("fsuid-map-fail-on-error"),
@@ -324,8 +324,8 @@ func newSysboxMgr(ctx *cli.Context) (*SysboxMgr, error) {
 		logrus.Info("Ignoring chown of /sys inside container.")
 	}
 
-	if !mgrCfg.allowTrustedXattr {
-		logrus.Info("Disallowing trusted.overlay.opaque inside container.")
+	if mgrCfg.allowTrustedXattr {
+		logrus.Info("Allowing trusted.overlay.opaque inside container.")
 	}
 
 	if mgrCfg.honorCaps {


### PR DESCRIPTION
Prior to this commit, Sysbox allowed trusted xattr* syscalls inside Sysbox containers by default (e.g., setfattr -n trusted.overlay.opaque -v "y" <somefile>).

With this commit, Sysbox will disallow xattr* syscalls inside Sysbox containers by default. Users can always revert to the prior behavior by either passing the "SYSBOX_ALLOW_TRUSTED_XATTR=TRUE" environment variable to a container (e.g., docker run -e SYSBOX_ALLOW_TRUSTED_XATTR=TRUE ...), or by passing the --allow-trusted-xattr flag in sysbox-mgr.

Rationale for this change:

Allowing trusted xattr* syscalls inside (unprivileged) Sysbox containers used to be useful to run older versions of Docker engine inside the container (Docker < 20.10.9). That's because older versions of Docker would set the trusted.overlay.opaque extended file attribute when setting up the container's filesystem. However, supporting this required Sysbox to intercept xattr* syscalls, which often had a heavy negative impact on performance.

Starting with Docker engine 20.10.9, Docker now uses the "user.overlay.opaque" extended file attribute (rather than the "trusted.overlay.opaque" attribute) to set up the container's filesystem inside unprivileged containers such as Sysbox containers. Therefore, Sysbox no longer needs to intercept xattr* syscalls to run Docker engine inside Sysbox containers, and performance can be improved.

Note that other apps that run inside Sysbox containers may still use "trusted.*" extended file attributes. For those apps to run properly, users will now need to configure Sysbox to trap xattr syscalls, as described above.

But such apps are the exception rather than the rule, so it makes sense for Sysbox to not allow xattr syscalls by default (to improve performance) and let users configure Sysbox to trap such syscalls for containers that actually need it.