### PR TITLE
Fix parsing of subid limits in /etc/login.defs

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -222,8 +222,9 @@ func getSubidLimits(file string) ([]uint64, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
+		line = strings.TrimLeft(line, " \t")
 		for token, pos := range tokens {
-			if strings.Contains(line, token) {
+			if strings.HasPrefix(line, token) {
 				valStr := strings.Fields(line)
 				if len(valStr) < 2 {
 					return limits, fmt.Errorf("failed to parse file %s: line %s: expected two fields, found %d field(s)", file, line, len(valStr))
@@ -933,7 +934,7 @@ func checkIDMapMountSupport(ctx *cli.Context) (bool, bool, error) {
 		return false, false, fmt.Errorf("failed to chmod %s to 0755: %s", sysboxLibDir, err)
 	}
 
-	defer func() () {
+	defer func() {
 		os.Chmod(sysboxLibDir, origPerm)
 	}()
 
@@ -969,7 +970,7 @@ func checkShiftfsSupport(ctx *cli.Context) (bool, bool, error) {
 		return false, false, fmt.Errorf("failed to chmod %s to 0755: %s", sysboxLibDir, err)
 	}
 
-	defer func() () {
+	defer func() {
 		os.Chmod(sysboxLibDir, origPerm)
 	}()
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -324,14 +324,16 @@ func TestGetSubidLimits(t *testing.T) {
 
 	// fake login.defs data
 	fileData := `# some comments
+# a comment with SUB_UID_MIN and SUB_UID_MAX; should be ignored by parser
 some data
 SUB_UID_MIN    100000
 some data
-SUB_UID_MAX\t 600100000
+   SUB_UID_MAX\t 600100000
 some data
+ \t    # another comment with SUB_GID_MIN and SUB_GID_MAX
 SUB_GID_MIN 100000
 some data
-SUB_GID_MAX\t\t 2147483648
+ SUB_GID_MAX\t\t 2147483648
 # some more comments`
 
 	want := []uint64{100000, 600100000, 100000, 2147483648}


### PR DESCRIPTION
The parser had a bug where it was looking for SUB_UID_MIN, SUB_UID_MAX, etc., in the `/etc/login.defs` file, but not ignoring them within comment lines. Fix this.

Fixes [issue #870](https://github.com/nestybox/sysbox/issues/870).