### PR TITLE
Add feature to auto-mount binfmt_misc in Sysbox containers.

### DIFF
--- a/mgr.go
+++ b/mgr.go
@@ -103,6 +103,7 @@ type mgrConfig struct {
 	noInnerImgPreload       bool
 	noShiftfsOnFuse         bool
 	relaxedReadOnly         bool
+	mountBinfmtMisc         bool
 }
 
 type SysboxMgr struct {
@@ -275,6 +276,33 @@ func newSysboxMgr(ctx *cli.Context) (*SysboxMgr, error) {
 		}
 	}
 
+	syscontMode := ctx.GlobalBoolT("syscont-mode")
+	if syscontMode {
+		logrus.Info("System container mode enabled.")
+	}
+
+	mountBinfmtMisc := false
+	if syscontMode {
+		binfmtMiscPresent, err := linuxUtils.KernelModSupported("binfmt_misc")
+		if err != nil {
+			return nil, fmt.Errorf("binfmt_misc kernel module check failed: %v", err)
+		}
+
+		if binfmtMiscPresent {
+			binfmtMiscNamespaced, err := linuxUtils.BinfmtMiscNamespacingSupported()
+			if err != nil {
+				return nil, fmt.Errorf("failed to check kernel support for binfmt_misc namespacing: %v", err)
+			}
+
+			if binfmtMiscNamespaced {
+				logrus.Info("binfmt_misc namespacing supported by kernel; will auto mount it in containers.")
+				mountBinfmtMisc = true
+			} else {
+				logrus.Info("binfmt_misc namespacing not supported by kernel; won't auto mount it in containers.")
+			}
+		}
+	}
+
 	mgrCfg := mgrConfig{
 		aliasDns:                ctx.GlobalBoolT("alias-dns"),
 		shiftfsOk:               shiftfsOk,
@@ -285,11 +313,12 @@ func newSysboxMgr(ctx *cli.Context) (*SysboxMgr, error) {
 		ignoreSysfsChown:        ctx.GlobalBool("ignore-sysfs-chown"),
 		allowTrustedXattr:       ctx.GlobalBool("allow-trusted-xattr"),
 		honorCaps:               ctx.GlobalBool("honor-caps"),
-		syscontMode:             ctx.GlobalBoolT("syscont-mode"),
+		syscontMode:             syscontMode,
 		relaxedReadOnly:         ctx.GlobalBool("relaxed-read-only"),
 		fsuidMapFailOnErr:       ctx.GlobalBool("fsuid-map-fail-on-error"),
 		noInnerImgPreload:       !syncVolToRootfs,
 		noShiftfsOnFuse:         ctx.GlobalBool("disable-shiftfs-on-fuse"),
+		mountBinfmtMisc:         mountBinfmtMisc,
 	}
 
 	if !mgrCfg.aliasDns {
@@ -1043,6 +1072,17 @@ func (mgr *SysboxMgr) reqMounts(id string, rootfsUidShiftType idShiftUtils.IDShi
 		mgr.ctLock.Lock()
 		mgr.contTable[id] = info
 		mgr.ctLock.Unlock()
+	}
+
+	// Add the binfmt_misc mount
+	if mgr.mgrCfg.mountBinfmtMisc {
+		binfmtMiscMount := specs.Mount{
+			Destination: "/proc/sys/fs/binfmt_misc",
+			Source:      "binfmt_misc",
+			Type:        "binfmt_misc",
+			Options:     []string{"noexec", "nosuid", "nodev"},
+		}
+		containerMnts = append(containerMnts, binfmtMiscMount)
 	}
 
 	// Dispatch a thread that checks if the container will be auto-removed after it stops


### PR DESCRIPTION
Starting with Linux kernel 6.7, binfmt_misc is namespaced per user-ns. See:

https://git.kernel.org/pub/scm/linux/kernel/git/vfs/vfs.git/commit/?h=vfs.binfmt_misc&id=ecddcab2d1b15fea782889237093bd069979c8c7

Therefore, add support for auto-mounting it in Sysbox containers, as this allows multi-arch builds and other use-cases inside the containers.