### PR TITLE
Add edition and version info in log.

### DIFF
--- a/main.go
+++ b/main.go
@@ -211,7 +211,13 @@ func main() {
 
 	app.Action = func(ctx *cli.Context) error {
 
-		logrus.Info("Starting ...")
+		logrus.Info("Starting sysbox-mgr")
+		logrus.Infof("Edition: %s", edition)
+		logrus.Infof("Version: %s", version)
+
+		if commitId != "" {
+			logrus.Infof("Commit-ID: %s", commitId)
+		}
 
 		// If requested, launch cpu/mem profiling data collection.
 		profile, err := runProfiler(ctx)


### PR DESCRIPTION
When starting sysbox-mgr, the log will now show the edition and version info:

```
time="2025-01-25 04:06:27" level=info msg="Starting sysbox-mgr"
time="2025-01-25 04:06:27" level=info msg="Edition: Community Edition (CE)"
time="2025-01-25 04:06:27" level=info msg="Version: 0.6.6"
...
```