### PR TITLE
feat: Add external user namespace support

### DIFF
--- a/mgr.go
+++ b/mgr.go
@@ -81,6 +81,7 @@ type containerInfo struct {
 	uidMappings            []specs.LinuxIDMapping
 	gidMappings            []specs.LinuxIDMapping
 	subidAllocated         bool
+	externalUserNS         bool   // true when using K8s/Containerd-provided mappings; do not allocate
 	rootfsCloned           bool
 	rootfsUidShiftType     idShiftUtils.IDShiftType
 	rootfsOnOvfs           bool
@@ -548,7 +549,11 @@ func (mgr *SysboxMgr) register(regInfo *ipcLib.RegistrationInfo) (*ipcLib.Contai
 	info.netns = netns
 	info.userns = userns
 
-	if !info.subidAllocated {
+	if regInfo.ExternalUserNS {
+		info.externalUserNS = true
+		info.uidMappings = uidMappings
+		info.gidMappings = gidMappings
+	} else if !info.subidAllocated {
 		info.uidMappings = uidMappings
 		info.gidMappings = gidMappings
 	}
@@ -576,7 +581,7 @@ func (mgr *SysboxMgr) register(regInfo *ipcLib.RegistrationInfo) (*ipcLib.Contai
 
 	// If this container's netns is shared with other containers, it's userns
 	// (and associated ID mappings) must be shared too.
-	if len(sameNetns) > 1 && userns == "" {
+	if len(sameNetns) > 1 && userns == "" && !info.externalUserNS {
 		otherContSameNetnsInfo, ok := mgr.contTable[sameNetns[0]]
 		if !ok {
 			mgr.ctLock.Unlock()
@@ -1233,6 +1238,16 @@ func (mgr *SysboxMgr) allocSubid(id string, size uint64) (uint32, uint32, error)
 	if !found {
 		return 0, 0, fmt.Errorf("container %s is not registered",
 			formatter.ContainerID{id})
+	}
+
+	// External UserNS: use the provided mappings; do not allocate from pool.
+	// Sysbox-fs will be configured with these mappings for ownership translation.
+	if info.externalUserNS {
+		if len(info.uidMappings) == 0 || len(info.gidMappings) == 0 {
+			return 0, 0, fmt.Errorf("container %s has external UserNS but no UID/GID mappings",
+				formatter.ContainerID{id})
+		}
+		return info.uidMappings[0].HostID, info.gidMappings[0].HostID, nil
 	}
 
 	// If we are being asked to allocate ID mappings for a new container, do it.


### PR DESCRIPTION
# Support for externally created user namespaces (e.g. Kubernetes 1.33 `hostUsers: false`)

## Summary

This change adds support for **externally created user namespaces**, such as those created by Kubernetes 1.33 when using `hostUsers: false`. Sysbox can now attach to and manage containers that run inside user namespaces created by the orchestrator rather than by Sysbox itself.

## Motivation

Kubernetes 1.33 introduces the ability to run pods with `hostUsers: false`, which creates a user namespace per pod. For Sysbox to support this model, it must:

- Detect when the container is already running in an external user namespace
- Use that namespace instead of creating its own
- Coordinate with sysbox-mgr and sysbox-ipc so that ID mappings, rootfs, and other Sysbox features work correctly with the external userns

This PR (along with the related changes in sysbox-ipc and sysbox-mgr) implements that support end-to-end.

## Related PRs

This is part of a coordinated change across the Sysbox repos. Please review and merge in dependency order where applicable:

- **sysbox-runc:** [link to sysbox-runc PR](https://github.com/nestybox/sysbox-runc/pull/109)
- **sysbox-ipc:** [link to sysbox-ipc PR](https://github.com/nestybox/sysbox-ipc/pull/36)
- **sysbox-mgr:** [link to sysbox-mgr PR](https://github.com/nestybox/sysbox-mgr/pull/79)

## Testing

Tested on **AWS EKS 1.33.5** with **Amazon Linux 2023** (kernel **6.1**) using containerd.

The following pod spec was used to verify behavior with `hostUsers: false` and `runtimeClassName: sysbox-runc`. The pod runs a systemd-based workload with Docker Compose (Postgres, Nginx, Redis) inside the Sysbox container:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: debian13
spec:
  hostUsers: false
  runtimeClassName: sysbox-runc
  containers:
  - name: dev
    image: <your-image>   # Replace with your container image
    command: ["sh", "-c"]
    args:
    - |
      # Create the working directory
      mkdir -p /opt/myapp

      # Create the docker-compose.yml
      cat > /opt/myapp/docker-compose.yml << 'EOF_COMPOSE'
      services:
        db:
          image: postgres:latest
          container_name: postgres
          environment:
            POSTGRES_USER: your_user
            POSTGRES_PASSWORD: your_password
            POSTGRES_DB: your_database
        web:
          image: nginx:latest
          container_name: nginx
        cache:
          image: redis:latest
          container_name: redis
      EOF_COMPOSE

      # Create the systemd service file using a heredoc
      cat > /etc/systemd/system/sysboxbddtest.service << 'EOF_SERVICE'
      [Unit]
      Description=My Docker Compose Application
      Requires=docker.service
      After=docker.service

      [Service]
      WorkingDirectory=/opt/myapp
      ExecStart=/usr/bin/docker compose -p myapp up
      ExecStop=/usr/bin/docker compose -p myapp down
      Restart=no

      [Install]
      WantedBy=multi-user.target
      EOF_SERVICE

      systemctl enable sysboxbddtest.service
      exec /sbin/init
  restartPolicy: Never
```

**Test environment:**

| Component   | Version / details        |
|------------|---------------------------|
| Kubernetes | AWS EKS 1.33.5           |
| OS         | Amazon Linux 2023        |
| Kernel     | 6.1                       |
|Runtime  | Containerd |

Added the following to `/etc/containerd/config.toml`:

```
[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc]
  runtime_type = "io.containerd.runc.v2"
  base_runtime_spec = "/etc/containerd/sysbox-base-spec.json"
  
[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc.options]
  BinaryName = "/usr/bin/sysbox-runc"
  SupportsUserns = true
```

Created `/etc/containerd/sysbox-base-spec.json`:

```
{
  "ociVersion": "1.0.2",
  "process": {
    "capabilities": {
      "bounding": ["CAP_SYS_ADMIN", "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_ADMIN", "CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT", "CAP_SYS_PTRACE"],
      "effective": ["CAP_SYS_ADMIN", "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_ADMIN", "CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT", "CAP_SYS_PTRACE"],
      "inheritable": ["CAP_SYS_ADMIN", "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_ADMIN", "CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT", "CAP_SYS_PTRACE"],
      "permitted": ["CAP_SYS_ADMIN", "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_ADMIN", "CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT", "CAP_SYS_PTRACE"],
      "ambient": ["CAP_SYS_ADMIN", "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_ADMIN", "CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT", "CAP_SYS_PTRACE"]
    }
  },
  "linux": {
    "seccomp": {
      "defaultAction": "SCMP_ACT_ALLOW",
      "architectures": ["SCMP_ARCH_X86_64", "SCMP_ARCH_X86", "SCMP_ARCH_AARCH64", "SCMP_ARCH_ARM"],
      "syscalls": []
    }
  }
}
```

With this configuration, the pod runs with an externally created user namespace (`hostUsers: false`), and Sysbox correctly manages the container (systemd, Docker Compose, and nested containers) within that namespace.
****