### PR TITLE
mgr: refactor container removal check to support containerd snapshotter

### DIFF
--- a/mgr.go
+++ b/mgr.go
@@ -531,7 +531,7 @@ func (mgr *SysboxMgr) register(regInfo *ipcLib.RegistrationInfo) (*ipcLib.Contai
 			mntPrepRev:   []mntPrepRevInfo{},
 			shiftfsMarks: []shiftfs.MountPoint{},
 			rootfs:       rootfs,
-			rmWatchPath:  sanitizeRootfs(id, rootfs),
+			rmWatchPath:  getRmWatchPath(id, rootfs),
 			rootfsOnOvfs: rootfsOnOvfs,
 		}
 

--- a/utils.go
+++ b/utils.go
@@ -548,22 +548,15 @@ func cleanupWorkDirs() error {
 	return nil
 }
 
-// Sanitize the given container's rootfs.
-func sanitizeRootfs(id, rootfs string) string {
-
-	// Docker containers on overlayfs have a rootfs under "/var/lib/docker/overlay2/<container-id>/merged".
-	// However, Docker removes the "merged" directory during container stop and re-creates
-	// it during container start. Thus, we can't rely on the presence of "merged" to
-	// determine if a container was stopped or removed. Instead, we use the rootfs path up
-	// to <container-id>.
-
+// getRmWatchPath returns a path that can be monitored to know when the container
+// with the given ID is removed. Normally this is the container's rootfs, but for
+// Docker containers we monitor a different path because it removes the rootfs anytime
+// the container is stopped but not removed.
+func getRmWatchPath(id, rootfs string) string {
 	isDocker, err := dockerUtils.ContainerIsDocker(id, rootfs)
 	if err == nil && isDocker {
-		if strings.Contains(rootfs, "overlay2") && filepath.Base(rootfs) == "merged" {
-			return filepath.Dir(rootfs)
-		}
+		return "/var/lib/docker/containers/" + id
 	}
-
 	return rootfs
 }
 


### PR DESCRIPTION
## Summary

Refactors the container removal check so it works regardless of whether
Docker uses the legacy image store or the containerd snapshotter. The
prior implementation only handled the legacy store case.

## Testing

Validated with standard sysbox integration tests.