### PR TITLE
mgr: don't hold ctLock across the Docker query in register()

### DIFF
--- a/mgr.go
+++ b/mgr.go
@@ -515,6 +515,11 @@ func (mgr *SysboxMgr) register(regInfo *ipcLib.RegistrationInfo) (*ipcLib.Contai
 	uidMappings := regInfo.UidMappings
 	gidMappings := regInfo.GidMappings
 
+	// Compute the removal-watch path before taking ctLock: it may query Docker
+	// and must not be held across the global lock, or concurrent registrations
+	// would serialize behind it (e.g. when restoring many containers at once).
+	rmWatchPath := getRmWatchPath(id, rootfs)
+
 	mgr.ctLock.Lock()
 	info, found := mgr.contTable[id]
 	newContainer := !found
@@ -531,7 +536,7 @@ func (mgr *SysboxMgr) register(regInfo *ipcLib.RegistrationInfo) (*ipcLib.Contai
 			mntPrepRev:   []mntPrepRevInfo{},
 			shiftfsMarks: []shiftfs.MountPoint{},
 			rootfs:       rootfs,
-			rmWatchPath:  getRmWatchPath(id, rootfs),
+			rmWatchPath:  rmWatchPath,
 			rootfsOnOvfs: rootfsOnOvfs,
 		}
 


### PR DESCRIPTION
register() computes the container's removal-watch path (which may query Docker) while holding the global ctLock. When many containers register at once and Docker is slow, this serializes them unnecessarily. Compute the watch path before taking the lock so registrations can proceed concurrently.